### PR TITLE
Add poi_weight as optional field - QMAPS-282

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub fn load_and_index_pois(mut rubber: Rubber, conn: &Connection, dataset: &str)
 
     let stmt = conn.prepare(
         "
-        SELECT osm_id, lon, lat, class, name, tags, source, mapping_key, subclass FROM
+        SELECT osm_id, lon, lat, class, name, tags, source, mapping_key, subclass, rank FROM
         (
             SELECT osm_id,
                 st_x(st_transform(geometry, 4326)) as lon,

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -8,6 +8,7 @@ fn init(pg_wrapper: &PostgresWrapper) {
     create_tests_tables(&conn);
     populate_tables(&conn);
     load_poi_class_function(&conn);
+    load_poi_class_rank_function(&conn);
 }
 
 fn create_tests_tables(conn: &Connection) {
@@ -102,6 +103,41 @@ fn load_poi_class_function(conn: &Connection) {
             $$ LANGUAGE SQL IMMUTABLE;", &[]).unwrap();
 }
 
+fn load_poi_class_rank_function(conn: &Connection) {
+    conn.execute(
+        "
+            CREATE OR REPLACE FUNCTION poi_class_rank(class TEXT)
+            RETURNS INT AS $$
+                SELECT CASE class
+                    WHEN 'hospital' THEN 20
+                    WHEN 'railway' THEN 40
+                    WHEN 'bus' THEN 50
+                    WHEN 'attraction' THEN 70
+                    WHEN 'harbor' THEN 75
+                    WHEN 'college' THEN 80
+                    WHEN 'school' THEN 85
+                    WHEN 'stadium' THEN 90
+                    WHEN 'zoo' THEN 95
+                    WHEN 'town_hall' THEN 100
+                    WHEN 'campsite' THEN 110
+                    WHEN 'cemetery' THEN 115
+                    WHEN 'park' THEN 120
+                    WHEN 'library' THEN 130
+                    WHEN 'police' THEN 135
+                    WHEN 'post' THEN 140
+                    WHEN 'golf' THEN 150
+                    WHEN 'shop' THEN 400
+                    WHEN 'grocery' THEN 500
+                    WHEN 'fast_food' THEN 600
+                    WHEN 'clothing_store' THEN 700
+                    WHEN 'bar' THEN 800
+                    ELSE 1000
+                END;
+            $$ LANGUAGE SQL IMMUTABLE;",
+        &[],
+    ).unwrap();
+}
+
 pub fn main_test(es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapper) {
     init(&pg_wrapper);
     let fafnir = concat!(env!("OUT_DIR"), "/../../../fafnir");
@@ -142,7 +178,7 @@ pub fn main_test(es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapper) 
     let properties_ocean_poi = &ocean_poi.properties;
     let amenity_tag = properties_ocean_poi
         .into_iter()
-        .find(|&p| p.key=="amenity")
+        .find(|&p| p.key == "amenity")
         .unwrap();
     assert_eq!(amenity_tag.value, "cafe".to_string());
 }


### PR DESCRIPTION
This PR only adds the rank computed from omt as a POI property.
To add this property as a field of POI a change to mimir would be required first.