### PR TITLE
WIP multithread import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - rust: nightly
       before_script: rustup component add rustfmt-preview
-      script: cargo fmt --all -- --write-mode diff
+      script: cargo fmt --all -- --check 
     - rust: stable
       script:
         - cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +138,33 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.4.0 (git+https://github.com/iron/logger.git)",
  "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "valico 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bragi"
+version = "1.2.0"
+source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
+dependencies = [
+ "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-version 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.4.0 (git+https://github.com/iron/logger.git)",
+ "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -248,9 +283,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmogony"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geos 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osm_boundaries_utils 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -312,6 +403,16 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "enum-primitive-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,10 +442,12 @@ dependencies = [
  "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
- "mimirsbrunn 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "mimirsbrunn 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -475,6 +578,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "geos"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "get-corresponding-derive"
 version = "0.1.0"
 source = "git+https://github.com/CanalTP/navitia_model#f1d8e9d36c49aa798abcba4d72e2f25ff5619e35"
@@ -496,6 +613,14 @@ dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -688,6 +813,11 @@ version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +896,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +932,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimir"
+version = "1.2.0"
+source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
+dependencies = [
+ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-json 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mimirsbrunn"
 version = "1.2.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#1cfbd084bc4365194e08f8fc7e13f1dbd7f70bc7"
+source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
 dependencies = [
- "bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "bragi 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -811,7 +971,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mdo 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
  "navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1238,6 +1398,27 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rayon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1558,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1617,17 @@ dependencies = [
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1585,11 +1782,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1784,6 +1998,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +2142,14 @@ dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
@@ -1931,6 +2158,7 @@ dependencies = [
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -1939,6 +2167,7 @@ dependencies = [
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
 "checksum bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
+"checksum bragi 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
@@ -1953,7 +2182,11 @@ dependencies = [
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum cookie 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d53b80dde876f47f03cda35303e368a79b91c70b0d65ecba5fd5280944a08591"
+"checksum cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "478ac4796c8294593c5747134bf142c154edd81bf06cff3c11e718c409348ea8"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e7a9e063dcebdb56c306f23e672bfd31df3da8ec5f6d696b35f2c29c2a9572f0"
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
@@ -1962,6 +2195,7 @@ dependencies = [
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0f475037312b91d34dbc3142a1ad3980ef0d070c7a855ce238afdd5e987cfecc"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
@@ -1979,9 +2213,11 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3f587a8e7ce8b1633c44a4a24bbeb6dad09f1db740ec335a072e7a1eeb6de8"
 "checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
+"checksum geos 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aeaa37068bddb1783cf559ec6c23dcfa49a50b09b93158e5219b431460f6419c"
 "checksum get-corresponding-derive 0.1.0 (git+https://github.com/CanalTP/navitia_model)" = "<none>"
 "checksum git-version 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d02f8926bb77111241ffb545b1af2669e629d66f7a5ff94547d97341a04ba41d"
 "checksum gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89d64d16c4e0ab924799d713bf939dd16a2e9d3e71afe9f2b2977f38a04e0188"
+"checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
@@ -2004,6 +2240,7 @@ dependencies = [
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum logger 0.4.0 (git+https://github.com/iron/logger.git)" = "<none>"
@@ -2015,9 +2252,11 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
-"checksum mimirsbrunn 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
+"checksum mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
+"checksum mimirsbrunn 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum nalgebra 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19f2bd263c9a2d334766e8056b370e8cdf9fe292a286a2ea8eba2126fe90100e"
@@ -2064,6 +2303,8 @@ dependencies = [
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
+"checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
+"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
@@ -2079,6 +2320,7 @@ dependencies = [
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53132b0cd2f8955381c7c0410a64a5a7e5260252e69bab36e36d2220c4ee6083"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "d3bcee660dcde8f52c3765dd9ca5ee36b4bf35470a738eb0bd5a8752b0389645"
@@ -2086,6 +2328,7 @@ dependencies = [
 "checksum serde_derive_internals 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89b340a48245bc03ddba31d0ff1709c118df90edc6adabaca4aac77aea181cce"
 "checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
 "checksum serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5c508584d9913df116b91505eec55610a2f5b16e9ed793c46e4d0152872b3e74"
+"checksum serde_yaml 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "107bb818146aaf922e7bbcf6a940f1db2f0dcf381779b451e400331b2c6f86db"
 "checksum sha2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7daca11f2fdb8559c4f6c588386bed5e2ad4b6605c1442935a7f08144a918688"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2f7bfce6405155042d42ec0e645efe43eddedd7be280063ce0623b120014e7f9"
@@ -2103,7 +2346,9 @@ dependencies = [
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum structopt 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "783cb22d520b177a3772e520d04a3c7970d51c3b647ba80739f99be01131b54f"
 "checksum structopt 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbf9b178b64479997d9515aa4a6956ada20a9829fa03fee3bbcff5962e4e405"
+"checksum structopt-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4da119c9a7a1eccb7c6de0c1eb3f7ed1c11138624d092b3687222aeed8f1375c"
 "checksum structopt-derive 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "29040b33bfc5dae3a321f79cbcd86813a5f024e3040a31f057188e7f2b6228ba"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
@@ -2129,6 +2374,7 @@ dependencies = [
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
@@ -2149,3 +2395,4 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
+"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,33 +120,7 @@ dependencies = [
 [[package]]
 name = "bragi"
 version = "1.2.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#1cfbd084bc4365194e08f8fc7e13f1dbd7f70bc7"
-dependencies = [
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "logger 0.4.0 (git+https://github.com/iron/logger.git)",
- "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
- "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "valico 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bragi"
-version = "1.2.0"
-source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
+source = "git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe#58c7b9fc1ddb05122cb0433672065579e60e2f21"
 dependencies = [
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,7 +130,7 @@ dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.4.0 (git+https://github.com/iron/logger.git)",
- "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "mimir 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,15 +372,15 @@ dependencies = [
 name = "fafnir"
 version = "0.1.0"
 dependencies = [
- "bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "bragi 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
- "mimirsbrunn 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "mimir 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
+ "mimirsbrunn 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
  "par-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -867,30 +841,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "1.2.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#1cfbd084bc4365194e08f8fc7e13f1dbd7f70bc7"
-dependencies = [
- "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-json 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mimir"
-version = "1.2.0"
-source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
+source = "git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe#58c7b9fc1ddb05122cb0433672065579e60e2f21"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,9 +865,9 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "1.2.0"
-source = "git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe#9c74b26ba1f6d110b782feec6f95538755a86506"
+source = "git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe#58c7b9fc1ddb05122cb0433672065579e60e2f21"
 dependencies = [
- "bragi 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "bragi 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,12 +878,12 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mdo 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "mimir 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)",
  "navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2095,8 +2046,7 @@ dependencies = [
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
-"checksum bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
-"checksum bragi 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
+"checksum bragi 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)" = "<none>"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
@@ -2179,9 +2129,8 @@ dependencies = [
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
-"checksum mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
-"checksum mimirsbrunn 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
+"checksum mimir 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)" = "<none>"
+"checksum mimirsbrunn 1.2.0 (git+https://github.com/antoine-de/mimirsbrunn.git?branch=threadSafe)" = "<none>"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum nalgebra 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19f2bd263c9a2d334766e8056b370e8cdf9fe292a286a2ea8eba2126fe90100e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,14 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,37 +305,6 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,8 +407,8 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
  "mimirsbrunn 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)",
+ "par-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -894,11 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "memoffset"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mime"
@@ -1398,27 +1354,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rayon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,11 +1490,6 @@ dependencies = [
 [[package]]
 name = "safemem"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scopeguard"
-version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2158,7 +2088,6 @@ dependencies = [
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
-"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -2184,9 +2113,6 @@ dependencies = [
 "checksum cookie 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d53b80dde876f47f03cda35303e368a79b91c70b0d65ecba5fd5280944a08591"
 "checksum cosmogony 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "478ac4796c8294593c5747134bf142c154edd81bf06cff3c11e718c409348ea8"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
-"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
-"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e7a9e063dcebdb56c306f23e672bfd31df3da8ec5f6d696b35f2c29c2a9572f0"
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
@@ -2252,7 +2178,6 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
 "checksum mimir 1.2.0 (git+https://github.com/amatissart/mimirsbrunn.git?branch=threadSafe)" = "<none>"
@@ -2303,8 +2228,6 @@ dependencies = [
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
-"checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
-"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
@@ -2320,7 +2243,6 @@ dependencies = [
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53132b0cd2f8955381c7c0410a64a5a7e5260252e69bab36e36d2220c4ee6083"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "d3bcee660dcde8f52c3765dd9ca5ee36b4bf35470a738eb0bd5a8752b0389645"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ log = "0.4"
 geo = "0.6"
 postgres = "0.15"
 fallible-iterator = "0.1"
-mimir = { git = "https://github.com/amatissart/mimirsbrunn.git", branch = "threadSafe" }
-mimirsbrunn = { git = "https://github.com/amatissart/mimirsbrunn.git", branch = "threadSafe" }
+mimir = { git = "https://github.com/antoine-de/mimirsbrunn.git", branch = "threadSafe" }
+mimirsbrunn = { git = "https://github.com/antoine-de/mimirsbrunn.git", branch = "threadSafe" }
 structopt = "0.2"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.0"
@@ -19,7 +19,8 @@ par-map = "0.1.2"
 [dev-dependencies]
 retry = "*"
 hyper = "0.10"
-bragi = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
+# bragi = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
+bragi = { git = "https://github.com/antoine-de/mimirsbrunn.git", branch = "threadSafe" }
 rs-es = {version = "0.10", default-features = false}
 serde = {version = "1", features = ["rc"]}
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ structopt = "0.2"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.0"
 itertools = "0.7.3"
-rayon = "1.0.1"
+par-map = "0.1.2"
 
 [dev-dependencies]
 retry = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,13 @@ log = "0.4"
 geo = "0.6"
 postgres = "0.15"
 fallible-iterator = "0.1"
-mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
-mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
+mimir = { git = "https://github.com/amatissart/mimirsbrunn.git", branch = "threadSafe" }
+mimirsbrunn = { git = "https://github.com/amatissart/mimirsbrunn.git", branch = "threadSafe" }
 structopt = "0.2"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.0"
+itertools = "0.7.3"
+rayon = "1.0.1"
 
 [dev-dependencies]
 retry = "*"

--- a/src/bin/fafnir.rs
+++ b/src/bin/fafnir.rs
@@ -24,7 +24,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         });
 
     let dataset = args.dataset;
-    fafnir::load_and_index_pois(&args.es, &conn, &dataset);
+    fafnir::load_and_index_pois(args.es, conn, dataset);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@ extern crate postgres;
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
-extern crate rayon;
 extern crate itertools;
+extern crate par_map;
 
-use rayon::prelude::*;
 use itertools::Itertools;
+use par_map::ParMap;
 use fallible_iterator::FallibleIterator;
-use mimir::rubber::Rubber;
+use mimir::rubber::{Rubber, TypedIndex};
 use mimir::{Coord, Poi, PoiType, Property};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use mimirsbrunn::utils::format_label;
@@ -119,7 +119,7 @@ fn build_poi(row: &Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Opti
     })
 }
 
-pub fn load_and_index_pois(es: &String, conn: &Connection, dataset: &str) {
+pub fn load_and_index_pois(es: &'static String, conn: &'static Connection, dataset: &str) {
     let rubber = &mut mimir::rubber::Rubber::new(es);
     let admins = rubber
         .get_admins_from_dataset(dataset)
@@ -171,26 +171,25 @@ pub fn load_and_index_pois(es: &String, conn: &Connection, dataset: &str) {
             r.map_err(|r| warn!("Impossible to load the row {:?}", r))
                 .ok()
         })
-        .chunks(20000);
+        .chunks(30000);
 
     rows_chunk
         .into_iter()
-        .for_each(|chunk| {
-            let rows_chunk: Vec<_> = chunk.collect();
-            rows_chunk.par_chunks(500)
-                .for_each(|par_chunk| {
-                    let mut rub = Rubber::new(es);
-                    let pois = par_chunk.into_iter().filter_map(|r| {
-                        build_poi(r, &admins_geofinder, &mut rub)
-                        .ok_or_else(|| warn!("Problem occurred in build_poi()"))
-                        .ok()
-                    });
-                    let mut rub2 = Rubber::new(es);
-                    match rub2.bulk_index(&poi_index, pois) {
-                        Err(e) => panic!("Failed to bulk insert pois because: {}", e),
-                        Ok(nb) => info!("Nb of indexed pois: {}", nb),
-                    }
-                })
+        .flat_map(|c| c)
+        .pack(1000)
+        .par_map(move |p| {
+            let mut rub = Rubber::new(es);
+            let pois = p.into_iter()
+                .filter_map(|r| {
+                    build_poi(&r, &admins_geofinder, &mut rub)
+                    .ok_or_else(|| warn!("Problem occurred in build_poi()"))
+                    .ok()
+                });
+            let mut rub2 = Rubber::new(es);
+            match rub2.bulk_index(&poi_index, pois) {
+                Err(e) => panic!("Failed to bulk insert pois because: {}", e),
+                Ok(nb) => info!("Nb of indexed pois: {}", nb),
+            };
         });
 
     rubber.publish_index(dataset, poi_index).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,23 @@ use std::collections::HashMap;
 const PG_BATCH_SIZE: i32 = 5000;
 
 fn build_poi_id(row: &Row) -> String {
+    let osm_id_int = row.get::<_, i64>("osm_id");
+    let pg_table = row.get::<_, String>("source");
+    let osm_type = if osm_id_int < 0 {
+        // Imposm uses negative osm_id for relations
+        "relation"
+    }
+    else if pg_table.ends_with("point") {
+        "node"
+    }
+    else {
+        "way"
+    };
+
     format!(
-        "pg:{source}:{id}",
-        source = row.get::<_, String>("source"),
-        id = row.get::<_, i64>("osm_id")
+        "osm:{osm_type}:{id}",
+        osm_type = osm_type,
+        id = osm_id_int.abs()
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@ extern crate postgres;
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
+extern crate rayon;
+extern crate itertools;
 
+use rayon::prelude::*;
+use itertools::Itertools;
 use fallible_iterator::FallibleIterator;
 use mimir::rubber::Rubber;
 use mimir::{Coord, Poi, PoiType, Property};
@@ -65,7 +69,7 @@ fn build_poi_properties(row: &Row, name: &str) -> Result<Vec<Property>, String> 
     Ok(properties)
 }
 
-fn build_poi(row: Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Option<Poi> {
+fn build_poi(row: &Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Option<Poi> {
     let name: String = row.get("name");
     let class: String = row.get("class");
     let lat = row.get_opt("lat")?
@@ -100,20 +104,6 @@ fn build_poi(row: Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Optio
         zip_codes: vec![],
         address: poi_address,
     })
-}
-
-fn index_pois<T>(rubber: &mut Rubber, dataset: &str, pois: T)
-where
-    T: Iterator<Item = Poi>,
-{
-    let poi_index = rubber.make_index(dataset).unwrap();
-
-    match rubber.bulk_index(&poi_index, pois) {
-        Err(e) => panic!("Failed to bulk insert pois because: {}", e),
-        Ok(nb) => info!("Nb of indexed pois: {}", nb),
-    }
-
-    rubber.publish_index(dataset, poi_index).unwrap();
 }
 
 pub fn load_and_index_pois(es: &String, conn: &Connection, dataset: &str) {
@@ -161,17 +151,34 @@ pub fn load_and_index_pois(es: &String, conn: &Connection, dataset: &str) {
     let trans = conn.transaction().unwrap();
 
     let rows = stmt.lazy_query(&trans, &[], PG_BATCH_SIZE).unwrap();
+    let poi_index = rubber.make_index(dataset).unwrap();
 
-    let pois = rows.iterator()
+    let rows_chunk = rows.iterator()
         .filter_map(|r| {
             r.map_err(|r| warn!("Impossible to load the row {:?}", r))
                 .ok()
         })
-        .filter_map(|r| {
-            build_poi(r, &admins_geofinder, rubber)
-                .ok_or_else(|| warn!("Problem occurred in build_poi()"))
-                .ok()
+        .chunks(20000);
+
+    rows_chunk
+        .into_iter()
+        .for_each(|chunk| {
+            let rows_chunk: Vec<_> = chunk.collect();
+            rows_chunk.par_chunks(500)
+                .for_each(|par_chunk| {
+                    let mut rub = Rubber::new(es);
+                    let pois = par_chunk.into_iter().filter_map(|r| {
+                        build_poi(r, &admins_geofinder, &mut rub)
+                        .ok_or_else(|| warn!("Problem occurred in build_poi()"))
+                        .ok()
+                    });
+                    let mut rub2 = Rubber::new(es);
+                    match rub2.bulk_index(&poi_index, pois) {
+                        Err(e) => panic!("Failed to bulk insert pois because: {}", e),
+                        Ok(nb) => info!("Nb of indexed pois: {}", nb),
+                    }
+                })
         });
 
-    index_pois(&mut Rubber::new(es), dataset, pois)
+    rubber.publish_index(dataset, poi_index).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,12 @@ extern crate slog_scope;
 extern crate itertools;
 extern crate par_map;
 
-use itertools::Itertools;
-use par_map::ParMap;
 use fallible_iterator::FallibleIterator;
-use mimir::rubber::{Rubber, TypedIndex};
+use mimir::rubber::Rubber;
 use mimir::{Coord, Poi, PoiType, Property};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use mimirsbrunn::utils::format_label;
+use par_map::ParMap;
 use postgres::rows::Row;
 use postgres::Connection;
 use std::collections::HashMap;
@@ -30,11 +29,9 @@ fn build_poi_id(row: &Row) -> String {
     let osm_type = if osm_id_int < 0 {
         // Imposm uses negative osm_id for relations
         "relation"
-    }
-    else if pg_table.ends_with("point") {
+    } else if pg_table.ends_with("point") {
         "node"
-    }
-    else {
+    } else {
         "way"
     };
 
@@ -46,7 +43,8 @@ fn build_poi_id(row: &Row) -> String {
 }
 
 fn build_poi_properties(row: &Row, name: &str) -> Result<Vec<Property>, String> {
-    let mut properties = row.get_opt::<_, HashMap<_, _>>("tags")
+    let mut properties = row
+        .get_opt::<_, HashMap<_, _>>("tags")
         .unwrap()
         .map_err(|err| {
             warn!("Unable to get tags: {:?}", err);
@@ -82,25 +80,33 @@ fn build_poi_properties(row: &Row, name: &str) -> Result<Vec<Property>, String> 
     Ok(properties)
 }
 
-fn build_poi(row: &Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Option<Poi> {
-    let name: String = row.get("name");
-    let class: String = row.get("class");
-    let lat = row.get_opt("lat")?
-        .map_err(|e| warn!("impossible to get lat for {} because {}", name, e))
-        .ok()?;
-    let lon = row.get_opt("lon")?
-        .map_err(|e| warn!("impossible to get lon for {} because {}", name, e))
-        .ok()?;
-    let poi_coord = Coord::new(lon, lat);
-    let admins = geofinder.get(&geo::Coordinate { x: lon, y: lat });
+fn locate_poi(poi: &mut Poi, geofinder: &AdminGeoFinder, rubber: &mut Rubber) {
+    let admins = geofinder.get(&poi.coord);
     let poi_address = rubber
-        .get_address(&poi_coord)
+        .get_address(&poi.coord)
         .ok()
         .and_then(|addrs| addrs.into_iter().next())
         .map(|addr| addr.address().unwrap());
     if poi_address.is_none() {
-        warn!("The poi {:?} doesn't have any address", name);
+        warn!("The poi {:?} doesn't have any address", &poi.name);
     }
+    poi.administrative_regions = admins;
+    poi.address = poi_address;
+    poi.label = format_label(&poi.administrative_regions, &poi.name);
+}
+
+fn build_poi(row: Row) -> Option<Poi> {
+    let name: String = row.get("name");
+    let class: String = row.get("class");
+    let lat = row
+        .get_opt("lat")?
+        .map_err(|e| warn!("impossible to get lat for {} because {}", name, e))
+        .ok()?;
+    let lon = row
+        .get_opt("lon")?
+        .map_err(|e| warn!("impossible to get lon for {} because {}", name, e))
+        .ok()?;
+    let poi_coord = Coord::new(lon, lat);
 
     Some(Poi {
         id: build_poi_id(&row),
@@ -109,20 +115,20 @@ fn build_poi(row: &Row, geofinder: &AdminGeoFinder, rubber: &mut Rubber) -> Opti
             id: class.clone(),
             name: class,
         },
-        label: format_label(&admins, &name),
-        administrative_regions: admins,
+        label: "".into(),
+        administrative_regions: vec![],
         properties: build_poi_properties(&row, &name).unwrap_or(vec![]),
         name: name,
         weight: 0.,
         zip_codes: vec![],
-        address: poi_address,
+        address: None,
     })
 }
 
-pub fn load_and_index_pois(es: &'static String, conn: &'static Connection, dataset: &str) {
-    let rubber = &mut mimir::rubber::Rubber::new(es);
+pub fn load_and_index_pois(es: String, conn: Connection, dataset: String) {
+    let rubber = &mut mimir::rubber::Rubber::new(&es);
     let admins = rubber
-        .get_admins_from_dataset(dataset)
+        .get_admins_from_dataset(&dataset)
         .unwrap_or_else(|err| {
             warn!(
                 "Administratives regions not found in es db for dataset {}. (error: {})",
@@ -164,33 +170,35 @@ pub fn load_and_index_pois(es: &'static String, conn: &'static Connection, datas
     let trans = conn.transaction().unwrap();
 
     let rows = stmt.lazy_query(&trans, &[], PG_BATCH_SIZE).unwrap();
-    let poi_index = rubber.make_index(dataset).unwrap();
+    let poi_index = rubber.make_index(&dataset).unwrap();
 
-    let rows_chunk = rows.iterator()
+    rows.iterator()
         .filter_map(|r| {
             r.map_err(|r| warn!("Impossible to load the row {:?}", r))
                 .ok()
         })
-        .chunks(30000);
-
-    rows_chunk
-        .into_iter()
-        .flat_map(|c| c)
+        .filter_map(|p| {
+            build_poi(p)
+                .ok_or_else(|| warn!("Problem occurred in build_poi()"))
+                .ok()
+        })
         .pack(1000)
-        .par_map(move |p| {
-            let mut rub = Rubber::new(es);
-            let pois = p.into_iter()
-                .filter_map(|r| {
-                    build_poi(&r, &admins_geofinder, &mut rub)
-                    .ok_or_else(|| warn!("Problem occurred in build_poi()"))
-                    .ok()
+        .par_map({
+            let i = poi_index.clone();
+            move |p| {
+                let mut rub = Rubber::new(&es);
+                let pois = p.into_iter().map(|mut r| {
+                    locate_poi(&mut r, &admins_geofinder, &mut rub);
+                    r
                 });
-            let mut rub2 = Rubber::new(es);
-            match rub2.bulk_index(&poi_index, pois) {
-                Err(e) => panic!("Failed to bulk insert pois because: {}", e),
-                Ok(nb) => info!("Nb of indexed pois: {}", nb),
-            };
-        });
+                let mut rub2 = Rubber::new(&es);
+                match rub2.bulk_index(&i, pois) {
+                    Err(e) => panic!("Failed to bulk insert pois because: {}", e),
+                    Ok(nb) => info!("Nb of indexed pois: {}", nb),
+                };
+            }
+        })
+        .for_each(|_| {});
 
-    rubber.publish_index(dataset, poi_index).unwrap();
+    rubber.publish_index(&dataset, poi_index).unwrap();
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -124,7 +124,8 @@ impl<'a> ElasticSearchWrapper<'a> {
     /// simple search on an index
     /// assert that the result is OK and transform it to a json Value
     pub fn search(&self, word: &str) -> serde_json::Value {
-        let res = self.rubber
+        let res = self
+            .rubber
             .get(&format!("munin/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -132,7 +133,8 @@ impl<'a> ElasticSearchWrapper<'a> {
     }
 
     pub fn search_on_global_stop_index(&self, word: &str) -> serde_json::Value {
-        let res = self.rubber
+        let res = self
+            .rubber
             .get(&format!("munin_global_stops/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -187,7 +189,8 @@ impl<'a> ElasticSearchWrapper<'a> {
                             v.into_iter()
                                 .filter_map(|json| {
                                     into_object(json).and_then(|obj| {
-                                        let doc_type = obj.get("_type")
+                                        let doc_type = obj
+                                            .get("_type")
                                             .and_then(|doc_type| doc_type.as_str())
                                             .map(|doc_type| doc_type.into());
 


### PR DESCRIPTION
use multiple threads to import fafnir.

This needs https://github.com/CanalTP/mimirsbrunn/pull/224 to be merged

For the moment the library used for the parallelization (`par-map`) uses nb_cpu * 2. The library will need to be updated in another PR to better configure this.

Note 2: this PR includes a commit "Define poi id using osm types" not really related to it, but needed for the moment for fafnir to continue to work properly.