### PR TITLE
Improvement on the poi loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: rust
 cache: cargo
 
-matrix:
-  include:
-    - rust: nightly
-      before_script: rustup component add rustfmt-preview
-      script: cargo fmt --all -- --check
-    - rust: stable
-      script:
-        - cargo build
-        - cargo test
-      services:
-        - docker
+rust:
+  - stable
+
+before_script: rustup component add rustfmt-preview
+
+script:
+- cargo test
+- cargo fmt --all -- --check
+
+services:
+- docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1645,7 +1645,7 @@ dependencies = [
  "nalgebra 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
 "checksum slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "053344c94c0e2b22da6305efddb698d7c485809427cf40555dc936085f67a9df"
 "checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
 "checksum slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bb5d9360b2b279b326824b3b4ca2402ead8a8138f0e5ec1900605c861bb6671"
-"checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
+"checksum smallvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e143aeee11cc8ece23c8336394de5138e598b84f5720fb8e895e2c6096322d88"
 "checksum socket2 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "71ebbe82fcdd697244ba7fe6e05e63b5c45910c3927e28469a04947494ff48d8"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum spade 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7acaf24b56259a7215446640e34558e7329f6a23107dfc5168a9e9236528610"

--- a/src/bin/fafnir.rs
+++ b/src/bin/fafnir.rs
@@ -20,6 +20,10 @@ struct Args {
     /// Number of threads used. The default is to use the number of cpus
     #[structopt(short = "n", long = "nb-threads")]
     nb_threads: Option<usize>,
+    /// Bounding box to filter the imported pois
+    /// The format is "lat1, lon1, lat2, lon2"
+    #[structopt(short = "b", long = "bounding-box")]
+    bounding_box: Option<String>,
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
@@ -30,7 +34,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
 
     let dataset = args.dataset;
     let nb_threads = args.nb_threads.unwrap_or(num_cpus::get());
-    fafnir::load_and_index_pois(args.es, conn, dataset, nb_threads);
+    fafnir::load_and_index_pois(args.es, conn, dataset, nb_threads, args.bounding_box);
     Ok(())
 }
 

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -336,9 +336,12 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
     assert!(&le_nomade.is_poi());
     let le_nomade = &le_nomade.poi().unwrap();
     assert_eq!(&le_nomade.id, "osm:way:42"); // the id in the database is '-42', so it's a way
-    // this poi has addresses osm tags, we should have read it
+                                             // this poi has addresses osm tags, we should have read it
     let le_nomade_addr = le_nomade.address.as_ref().unwrap();
-    assert_eq!(get_label(le_nomade_addr), &"7 rue spontini (bob's town)".to_string());
+    assert_eq!(
+        get_label(le_nomade_addr),
+        &"7 rue spontini (bob's town)".to_string()
+    );
     assert_eq!(get_house_number(le_nomade_addr), &"7".to_string());
     assert_eq!(get_zip_codes(le_nomade_addr), vec!["75016".to_string()]);
 
@@ -371,11 +374,10 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
         .unwrap();
     assert_eq!(poi_subclass.value, "airport".to_string());
 
-    // the '4 gusto' has a tag addr:street but no housenumber, we should not read the address from osm 
+    // the '4 gusto' has a tag addr:street but no housenumber, we should not read the address from osm
     // and since it's too far from another address it should not have an address
-    let gusto_query: Vec<mimir::Place> = es_wrapper
-        .search_and_filter("4 gusto", |_| true)
-        .collect();
+    let gusto_query: Vec<mimir::Place> =
+        es_wrapper.search_and_filter("4 gusto", |_| true).collect();
     assert_eq!(&gusto_query.len(), &1);
     let gusto = &gusto_query[0];
     assert!(&gusto.is_poi());
@@ -385,16 +387,18 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
 
     // the Spagnolo has some osm address tags and no addr:postcode
     // we should still read it's address from osm
-    let spagnolo_query: Vec<mimir::Place> = es_wrapper
-        .search_and_filter("spagnolo", |_| true)
-        .collect();
+    let spagnolo_query: Vec<mimir::Place> =
+        es_wrapper.search_and_filter("spagnolo", |_| true).collect();
     assert_eq!(&spagnolo_query.len(), &1);
     let spagnolo = &spagnolo_query[0];
     assert!(&spagnolo.is_poi());
     let spagnolo = &spagnolo.poi().unwrap();
     assert_eq!(&spagnolo.id, "osm:node:5590210422");
     let spagnolo_addr = spagnolo.address.as_ref().unwrap();
-    assert_eq!(get_label(spagnolo_addr), &"12 rue bob (bob's town)".to_string());
+    assert_eq!(
+        get_label(spagnolo_addr),
+        &"12 rue bob (bob's town)".to_string()
+    );
     assert_eq!(get_house_number(spagnolo_addr), &"12".to_string());
     assert!(get_zip_codes(spagnolo_addr).is_empty());
 }

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -87,15 +87,15 @@ fn populate_tables(conn: &Connection) {
     // this poi is located at lon=2, lat=2
     conn.execute("INSERT INTO osm_poi_point (osm_id, name, name_en, name_de, subclass, mapping_key, station, funicular, information, uic_ref, geometry, tags) 
     VALUES (5590210422, 'Spagnolo',null,null, 'clothes', 'shop',null,null,null,null, '0101000020E610000000000000000000400000000000000040'
-    , '\"name\"=>\"Spagnolo\", \"shop\"=>\"clothes\", \"name_int\"=>\"Spagnolo\", \"name:latin\"=>\"Spagnolo\"')", &[]).unwrap();
+    , '\"name\"=>\"Spagnolo\", \"shop\"=>\"clothes\", \"name_int\"=>\"Spagnolo\", \"name:latin\"=>\"Spagnolo\",\"addr:housenumber\"=>\"12\",\"addr:street\"=>\"rue bob\"')", &[]).unwrap();
     // this poi is located at lon=3, lat=3
     conn.execute("INSERT INTO osm_poi_point (osm_id, name, name_en, name_de, subclass, mapping_key, station, funicular, information, uic_ref, geometry, tags) 
     VALUES (5590601521, '4 gusto',null,null, 'cafe', 'amenity',null,null,null,null, '0101000020E610000000000000000008400000000000000840'
-    , '\"name\"=>\"4 gusto\", \"amenity\"=>\"cafe\", \"name_int\"=>\"4 gusto\", \"name:latin\"=>\"4 gusto\"')", &[]).unwrap();
+    , '\"name\"=>\"4 gusto\", \"amenity\"=>\"cafe\", \"name_int\"=>\"4 gusto\", \"name:latin\"=>\"4 gusto\",\"addr:street\"=>\"rue spontini\"')", &[]).unwrap();
     // this poi is located at lon=4, lat=4
     conn.execute("INSERT INTO osm_poi_point (osm_id, name, name_en, name_de, subclass, mapping_key, station, funicular, information, uic_ref, geometry, tags) 
     VALUES (-42, 'Le nomade',null,null, 'bar', 'amenity',null,null,null,null, '0101000020E610000000000000000010400000000000001040'
-    , '\"name\"=>\"Le nomade\", \"amenity\"=>\"bar\", \"name:es\"=>\"Le nomade\", \"name_int\"=>\"Le nomade\", \"name:latin\"=>\"Le nomade\"')", &[]).unwrap();
+    , '\"name\"=>\"Le nomade\", \"amenity\"=>\"bar\", \"name:es\"=>\"Le nomade\", \"name_int\"=>\"Le nomade\", \"name:latin\"=>\"Le nomade\",\"addr:housenumber\"=>\"7\",\"addr:street\"=>\"rue spontini\",\"addr:postcode\"=>\"75016\"')", &[]).unwrap();
     // this poi is located at lon=5, lat=5
     conn.execute("INSERT INTO osm_aerodrome_label_point (id, osm_id, name, name_en, name_de, aerodrome_type, aerodrome, military, iata, icao, ele, geometry, tags) 
     VALUES (5934, 4505823836, 'Isla Cristina Agricultural Airstrip', null, null, null, null, null, null,  null, null, '0101000020E610000000000000000014400000000000001440'
@@ -208,6 +208,7 @@ fn make_test_admin() -> mimir::Admin {
         zone_type: None,
     }
 }
+
 fn make_test_address(city: mimir::Admin) -> mimir::Addr {
     let street = mimir::Street {
         id: "1234".to_string(),
@@ -335,6 +336,11 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
     assert!(&le_nomade.is_poi());
     let le_nomade = &le_nomade.poi().unwrap();
     assert_eq!(&le_nomade.id, "osm:way:42"); // the id in the database is '-42', so it's a way
+    // this poi has addresses osm tags, we should have read it
+    let le_nomade_addr = le_nomade.address.as_ref().unwrap();
+    assert_eq!(get_label(le_nomade_addr), &"7 rue spontini (bob's town)".to_string());
+    assert_eq!(get_house_number(le_nomade_addr), &"7".to_string());
+    assert_eq!(get_zip_codes(le_nomade_addr), vec!["75016".to_string()]);
 
     // Test that the airport 'Isla Cristina Agricultural Airstrip' has been imported in the elastic wrapper
     let airport_cristina: Vec<mimir::Place> = es_wrapper
@@ -364,6 +370,33 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
         .find(|&p| p.key == "poi_subclass")
         .unwrap();
     assert_eq!(poi_subclass.value, "airport".to_string());
+
+    // the '4 gusto' has a tag addr:street but no housenumber, we should not read the address from osm 
+    // and since it's too far from another address it should not have an address
+    let gusto_query: Vec<mimir::Place> = es_wrapper
+        .search_and_filter("4 gusto", |_| true)
+        .collect();
+    assert_eq!(&gusto_query.len(), &1);
+    let gusto = &gusto_query[0];
+    assert!(&gusto.is_poi());
+    let gusto = &gusto.poi().unwrap();
+    assert_eq!(&gusto.id, "osm:node:5590601521");
+    assert!(&gusto.address.is_none());
+
+    // the Spagnolo has some osm address tags and no addr:postcode
+    // we should still read it's address from osm
+    let spagnolo_query: Vec<mimir::Place> = es_wrapper
+        .search_and_filter("spagnolo", |_| true)
+        .collect();
+    assert_eq!(&spagnolo_query.len(), &1);
+    let spagnolo = &spagnolo_query[0];
+    assert!(&spagnolo.is_poi());
+    let spagnolo = &spagnolo.poi().unwrap();
+    assert_eq!(&spagnolo.id, "osm:node:5590210422");
+    let spagnolo_addr = spagnolo.address.as_ref().unwrap();
+    assert_eq!(get_label(spagnolo_addr), &"12 rue bob (bob's town)".to_string());
+    assert_eq!(get_house_number(spagnolo_addr), &"12".to_string());
+    assert!(get_zip_codes(spagnolo_addr).is_empty());
 }
 
 pub fn bbox_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapper) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -239,4 +239,9 @@ fn main_test() {
         ElasticSearchWrapper::new(&mut el_docker),
         PostgresWrapper::new(&pg_docker),
     );
+
+    fafnir_tests::bbox_test(
+        ElasticSearchWrapper::new(&mut el_docker),
+        PostgresWrapper::new(&pg_docker),
+    );
 }


### PR DESCRIPTION
this pr is a bit of a mix :confused: but all commits can be reviewed separatly.

add:
## the ability to filter by bbox

the bbox filtering is usefull especially for speeding up import and running tests (with docker_mimir)

the bounding box is given in the format:
--bounding-box="lat1, lon1, lat2, lon2"
eg
`--bounding-box="-5.4534286, 41.2632185, 9.8678344, 51.268318"

to filter on france

## filter pois that does not have any admins

filter pois that does not have any admins

pois that have no admins (not even a country) are likely outside the loaded zone (and in qwant's internal use, likely imported though osm updates)

We will have few info on them, it's better to filter them.

## read the admin from the address if there is one 
this will save a lookup on the geofinder

## read addresses from osm tags 
we read the addresses from the osm tags `addr:housenumber` and `addr:street`.
This save time as we do not a reverse geocoding and this is potentially more accurate as the address is filled by an osm contributor.

if available we also read the `addr:postcode`

for the moment we do not read `addr:city` or `addr:country` as it could lead to inconsistency with the cosmogony hierarchy

on the french dataset we load 59994 addresses with this