### PR TITLE
Call coord.is_valid instead of checking for NaN specifically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,11 +191,9 @@ fn build_poi(row: Row) -> Option<Poi> {
     let poi_coord = Coord::new(lon, lat);
 
     if !poi_coord.is_valid() {
-        /*
-            NaN may exist here because of proj transforms around poles.
-            Let's ignore this POI. It would break rtree assertions
-            when looking for admins.
-        */
+        // Ignore PoI if its coords from db are invalid.
+        // Especially, NaN values may exist because of projection
+        // transformations around poles.
         warn!("Got invalid coord for {} lon={},lat={}", id, lon, lat);
         return None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,26 +179,26 @@ fn build_poi(row: Row) -> Option<Poi> {
     let id = row.get("id");
     let name: String = row.get("name");
     let class: String = row.get("class");
-    let lat: f64 = row
+    let lat = row
         .get_opt("lat")?
         .map_err(|e| warn!("impossible to get lat for {} because {}", name, e))
         .ok()?;
-    let lon: f64 = row
+    let lon = row
         .get_opt("lon")?
         .map_err(|e| warn!("impossible to get lon for {} because {}", name, e))
         .ok()?;
 
-    if lat.is_nan() || lon.is_nan() {
+    let poi_coord = Coord::new(lon, lat);
+
+    if !poi_coord.is_valid() {
         /*
-            This may happen because of proj transforms around poles.
+            NaN may exist here because of proj transforms around poles.
             Let's ignore this POI. It would break rtree assertions
             when looking for admins.
         */
-        warn!("Got NaN in coords for {}: lon={},lat={}", id, lon, lat);
+        warn!("Got invalid coord for {} lon={},lat={}", id, lon, lat);
         return None;
     }
-
-    let poi_coord = Coord::new(lon, lat);
 
     Some(Poi {
         id: id,


### PR DESCRIPTION
This is a more robust fix, following #21.