### PR TITLE
Read both addr:* and contact:* tags to find housenumber and street

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,16 +156,25 @@ fn find_address(
     geofinder: &AdminGeoFinder,
     rubber: &mut Rubber,
 ) -> Option<mimir::Address> {
-    let osm_addr_tag = poi
-        .properties
+    let osm_addr_tag = ["addr:housenumber", "contact:housenumber"]
         .iter()
-        .find(|p| &p.key == "addr:housenumber")
-        .map(|p| &p.value);
-    let osm_street_tag = poi
-        .properties
+        .filter_map(|k| {
+            poi.properties
+                .iter()
+                .find(|p| &p.key == k)
+                .map(|p| &p.value)
+        })
+        .next();
+
+    let osm_street_tag = ["addr:street", "contact:street"]
         .iter()
-        .find(|p| &p.key == "addr:street")
-        .map(|p| &p.value);
+        .filter_map(|k| {
+            poi.properties
+                .iter()
+                .find(|p| &p.key == k)
+                .map(|p| &p.value)
+        })
+        .next();
 
     match (osm_addr_tag, osm_street_tag) {
         (Some(addr_tag), Some(street_tag)) => Some(build_new_addr(


### PR DESCRIPTION
Use `contact:housenumber` and `contact:street` as fallbacks to find the address that should be associated to a POI.

This was suggested in https://github.com/QwantResearch/qwantmaps/issues/28  
`contact:*` tags are sometimes used in OSM data to avoid duplicating addresses.  

More details on https://wiki.openstreetmap.org/wiki/Proposed_features/House_numbers/Bremen_Schema
