### PR TITLE
use sql-defined weight function

### DIFF
--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -403,9 +403,15 @@ fn load_poi_weight_function(conn: &Connection) {
             mapping_key varchar,
             tags hstore
         )
-        RETURNS integer AS $$
-            SELECT LENGTH(name)
-        $$ LANGUAGE SQL IMMUTABLE;
+        RETURNS REAL AS $$
+            DECLARE
+                result REAL;
+            BEGIN
+                SELECT INTO result
+                    1.0 - 1.0 / (1.0 + LENGTH(name)::real);
+                RETURN result;
+            END
+        $$ LANGUAGE plpgsql IMMUTABLE;
         ",
         &[],
     )

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -23,6 +23,7 @@ fn init_tests(
     load_labelgrid_function(&conn);
     load_poi_class_rank_function(&conn);
     load_layer_poi_function(&conn);
+    load_poi_weight_function(&conn);
     load_es_data(es_wrapper, country_code);
 }
 
@@ -387,6 +388,25 @@ RETURNS TEXT AS $$
     );
 $$ LANGUAGE SQL IMMUTABLE;
     ",
+        &[],
+    )
+    .unwrap();
+}
+
+/// This is a quick placeholder for the actual weight function.
+fn load_poi_weight_function(conn: &Connection) {
+    conn.execute(
+        "
+        CREATE OR REPLACE FUNCTION poi_display_weight(
+            name varchar,
+            subclass varchar,
+            mapping_key varchar,
+            tags hstore
+        )
+        RETURNS integer AS $$
+            SELECT LENGTH(name)
+        $$ LANGUAGE SQL IMMUTABLE;
+        ",
         &[],
     )
     .unwrap();

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -23,7 +23,7 @@ fn init_tests(
     load_labelgrid_function(&conn);
     load_poi_class_rank_function(&conn);
     load_layer_poi_function(&conn);
-    load_poi_weight_function(&conn);
+    load_poi_display_weight_function(&conn);
     load_es_data(es_wrapper, country_code);
 }
 
@@ -394,7 +394,7 @@ $$ LANGUAGE SQL IMMUTABLE;
 }
 
 /// This is a quick placeholder for the actual weight function.
-fn load_poi_weight_function(conn: &Connection) {
+fn load_poi_display_weight_function(conn: &Connection) {
     conn.execute(
         "
         CREATE OR REPLACE FUNCTION poi_display_weight(


### PR DESCRIPTION
Replace the former weight computation with an sql-defined weight function that will be set here: https://github.com/QwantResearch/kartotherian_docker/pull/85.

It may be unwise to use the same function for both the geocoding and the display, but it will be easy to change this way. I'll try to talk about it with @jbgriesner (who I think is the expert on this topic, even though there is only straightforward heuristics here ?)