### PR TITLE
add explicit `dyn` when using trait objects

### DIFF
--- a/tests/docker_wrapper/mod.rs
+++ b/tests/docker_wrapper/mod.rs
@@ -16,7 +16,7 @@ pub struct PostgresDocker {
 }
 
 impl PostgresDocker {
-    pub fn new() -> Result<PostgresDocker, Box<Error>> {
+    pub fn new() -> Result<PostgresDocker, Box<dyn Error>> {
         let mut pg_docker = PostgresDocker { ip: "".to_string() };
         pg_docker.setup()?;
         Ok(pg_docker)
@@ -26,7 +26,7 @@ impl PostgresDocker {
         format!("{}", self.ip)
     }
 
-    pub fn setup(&mut self) -> Result<(), Box<Error>> {
+    pub fn setup(&mut self) -> Result<(), Box<dyn Error>> {
         info!("Launching the PostgresWrapper docker");
         let (name, img) = ("postgres_fafnir_tests", "openmaptiles/postgis");
 
@@ -76,7 +76,7 @@ impl PostgresDocker {
 }
 
 impl ElasticsearchDocker {
-    pub fn new() -> Result<ElasticsearchDocker, Box<Error>> {
+    pub fn new() -> Result<ElasticsearchDocker, Box<dyn Error>> {
         let mut el_docker = ElasticsearchDocker { ip: "".to_string() };
         el_docker.setup()?;
         let rubber = Rubber::new(&el_docker.host());
@@ -88,7 +88,7 @@ impl ElasticsearchDocker {
         format!("http://{}:9200", self.ip)
     }
 
-    pub fn setup(&mut self) -> Result<(), Box<Error>> {
+    pub fn setup(&mut self) -> Result<(), Box<dyn Error>> {
         info!("Launching docker");
         let (name, img) = ("mimirsbrunn_fafnir_tests", "elasticsearch:2");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -157,7 +157,7 @@ impl<'a> ElasticSearchWrapper<'a> {
         &self,
         word: &str,
         predicate: F,
-    ) -> Box<Iterator<Item = mimir::Place> + 'b>
+    ) -> Box<dyn Iterator<Item = mimir::Place> + 'b>
     where
         F: 'b + FnMut(&mimir::Place) -> bool,
     {
@@ -169,7 +169,7 @@ impl<'a> ElasticSearchWrapper<'a> {
         word: &str,
         predicate: F,
         search_on_global_stops: bool,
-    ) -> Box<Iterator<Item = mimir::Place> + 'b>
+    ) -> Box<dyn Iterator<Item = mimir::Place> + 'b>
     where
         F: 'b + FnMut(&mimir::Place) -> bool,
     {
@@ -218,12 +218,12 @@ impl<'a> ElasticSearchWrapper<'a> {
                                 })
                                 .filter(predicate),
                         )
-                            as Box<Iterator<Item = mimir::Place>>)
+                            as Box<dyn Iterator<Item = mimir::Place>>)
                     }
                     _ => None,
                 }
             })
-            .unwrap_or(Box::new(None.into_iter()) as Box<Iterator<Item = mimir::Place>>)
+            .unwrap_or(Box::new(None.into_iter()) as Box<dyn Iterator<Item = mimir::Place>>)
     }
 }
 


### PR DESCRIPTION
Using bare trait objects is deprecated and now triggers a warning by
default: https://github.com/rust-lang/rust/pull/61203.