### PR TITLE
Fix poi class: poi_class() is already called by layer_poi()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ pub fn load_and_index_pois(
                 global_id AS id,
                 st_x(st_transform(geometry, 4326)) AS lon,
                 st_y(st_transform(geometry, 4326)) AS lat,
-                poi_class(subclass, mapping_key) AS class,
+                class,
                 name,
                 mapping_key,
                 subclass,


### PR DESCRIPTION
After the SQL query changed in #32, the `poi_class()` function is called twice, sometimes using a wrong "subclass" value (different from the "subclass" column).

We should simply use the "class" value that is returned by `layer_poi()`