### PR TITLE
Import non searchable pois into separate index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,10 +1020,10 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "mimirsbrunn 1.3.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2065,6 +2065,11 @@ dependencies = [
 [[package]]
 name = "odds"
 version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "once_cell"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4318,6 +4323,7 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
+"checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -236,7 +236,7 @@ dependencies = [
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "include_dir 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,7 +465,7 @@ dependencies = [
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -501,7 +501,7 @@ name = "bstr"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -560,7 +560,7 @@ name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -701,7 +701,7 @@ dependencies = [
  "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -740,7 +740,7 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -753,7 +753,7 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -772,7 +772,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ name = "derive_more"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1020,6 +1020,7 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "mimirsbrunn 1.3.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1323,7 +1324,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1582,7 +1583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1750,7 +1751,7 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "humanesort 0.1.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "navitia-poi-model 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1789,7 +1790,7 @@ dependencies = [
  "humanesort 0.1.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0 (git+https://github.com/canalTP/mimirsbrunn?rev=456e0be)",
  "navitia-poi-model 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1884,7 +1885,7 @@ name = "native-tls"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2079,7 +2080,7 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2485,7 +2486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2527,7 +2528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3007,7 +3008,7 @@ name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3231,7 +3232,7 @@ version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3493,7 +3494,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3548,7 +3549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3632,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3753,7 +3754,7 @@ dependencies = [
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iso4217 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "minidom 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3812,7 +3813,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3835,7 +3836,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4269,7 +4270,7 @@ dependencies = [
 "checksum json 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a38661a28126f8621fb246611288ae28935ddf180f5e21f2d0fbfe5e4131dbe"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)" = "c665266eb592905e8503ba3403020f4b8794d26263f412ca33171600eca9a6fa"
 "checksum libflate 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "45c97cf62125b79dcac52d506acdc4799f21a198597806947fd5f40dc7b93412"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ slog-scope = "4.0"
 itertools = "0.8"
 par-map = "0.1.4"
 num_cpus = "1.12"
-lazy_static = "1.4.0"
+once_cell = "1.3"
 
 [dev-dependencies]
 retry = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ slog-scope = "4.0"
 itertools = "0.8"
 par-map = "0.1.4"
 num_cpus = "1.12"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 retry = "*"

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -7,17 +7,7 @@ use mimirsbrunn::utils::find_country_codes;
 use std::ops::Deref;
 use std::sync::Arc;
 
-/// Read the osm address tags and build a mimir address from them
-///
-/// For the moment we read mostly `addr:city` or `addr:country`
-/// if available we also read `addr:postcode`
-///
-/// We also search for the admins that contains the coordinates of the poi
-/// and add them as the address's admins.
-///
-/// For the moment we do not read `addr:city` or `addr:country` as it could
-/// lead to inconsistency with the admins hierarchy
-pub fn build_new_addr(
+fn build_new_addr(
     addr_tag: &str,
     street_tag: &str,
     poi: &Poi,
@@ -27,7 +17,7 @@ pub fn build_new_addr(
         .properties
         .iter()
         .find(|p| &p.key == "addr:postcode")
-        .map(|p| p.value.clone());
+        .map(|p| p.value.to_owned());
     let postcodes = postcode.map_or(vec![], |p| vec![p]);
     let country_codes = find_country_codes(iter_admins(&admins));
     let street_label = format_street_label(street_tag, iter_admins(&admins), &country_codes);
@@ -60,6 +50,11 @@ pub fn build_new_addr(
     })
 }
 
+/// Build mimir Address from Poi,using osm address tags (if present)
+/// or using reverse geocoding
+///
+/// We also search for the admins that contains the coordinates of the poi
+/// and add them as the address's admins.
 pub fn find_address(
     poi: &Poi,
     geofinder: &AdminGeoFinder,

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -51,7 +51,7 @@ fn build_new_addr(
 }
 
 /// Build mimir Address from Poi,using osm address tags (if present)
-/// or using reverse geocoding
+/// or using reverse geocoding.
 ///
 /// We also search for the admins that contains the coordinates of the poi
 /// and add them as the address's admins.

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -1,0 +1,120 @@
+use mimir::rubber::Rubber;
+use mimir::Poi;
+use mimirsbrunn::admin_geofinder::AdminGeoFinder;
+use mimirsbrunn::labels::format_addr_name_and_label;
+use mimirsbrunn::labels::format_street_label;
+use mimirsbrunn::utils::find_country_codes;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Read the osm address tags and build a mimir address from them
+///
+/// For the moment we read mostly `addr:city` or `addr:country`
+/// if available we also read `addr:postcode`
+///
+/// We also search for the admins that contains the coordinates of the poi
+/// and add them as the address's admins.
+///
+/// For the moment we do not read `addr:city` or `addr:country` as it could
+/// lead to inconsistency with the admins hierarchy
+pub fn build_new_addr(
+    addr_tag: &str,
+    street_tag: &str,
+    poi: &Poi,
+    admins: Vec<Arc<mimir::Admin>>,
+) -> mimir::Address {
+    let postcode = poi
+        .properties
+        .iter()
+        .find(|p| &p.key == "addr:postcode")
+        .map(|p| p.value.clone());
+    let postcodes = postcode.map_or(vec![], |p| vec![p]);
+    let country_codes = find_country_codes(iter_admins(&admins));
+    let street_label = format_street_label(street_tag, iter_admins(&admins), &country_codes);
+    let (addr_name, addr_label) =
+        format_addr_name_and_label(addr_tag, street_tag, iter_admins(&admins), &country_codes);
+    let weight = admins.iter().find(|a| a.is_city()).map_or(0., |a| a.weight);
+    mimir::Address::Addr(mimir::Addr {
+        id: format!("addr_poi:{}", &poi.id),
+        house_number: addr_tag.into(),
+        name: addr_name,
+        street: mimir::Street {
+            id: format!("street_poi:{}", &poi.id),
+            name: street_tag.to_string(),
+            label: street_label,
+            administrative_regions: admins,
+            weight,
+            zip_codes: postcodes.clone(),
+            coord: poi.coord,
+            country_codes: country_codes.clone(),
+            ..Default::default()
+        },
+        label: addr_label,
+        coord: poi.coord,
+        approx_coord: None,
+        weight,
+        zip_codes: postcodes,
+        distance: None,
+        country_codes,
+        context: None,
+    })
+}
+
+pub fn find_address(
+    poi: &Poi,
+    geofinder: &AdminGeoFinder,
+    rubber: &mut Rubber,
+) -> Option<mimir::Address> {
+    if poi
+        .properties
+        .iter()
+        .any(|p| p.key == "poi_class" && p.value == "locality")
+    {
+        // We don't want to add address on hamlets.
+        return None;
+    }
+    let osm_addr_tag = ["addr:housenumber", "contact:housenumber"]
+        .iter()
+        .filter_map(|k| {
+            poi.properties
+                .iter()
+                .find(|p| &p.key == k)
+                .map(|p| &p.value)
+        })
+        .next();
+
+    let osm_street_tag = ["addr:street", "contact:street"]
+        .iter()
+        .filter_map(|k| {
+            poi.properties
+                .iter()
+                .find(|p| &p.key == k)
+                .map(|p| &p.value)
+        })
+        .next();
+
+    match (osm_addr_tag, osm_street_tag) {
+        (Some(addr_tag), Some(street_tag)) => Some(build_new_addr(
+            addr_tag,
+            street_tag,
+            poi,
+            geofinder.get(&poi.coord),
+        )),
+        _ => rubber
+            .get_address(&poi.coord)
+            .map_err(|e| {
+                warn!("get_address returned ES error for {}: {}", poi.id, e);
+                e
+            })
+            .ok()
+            .and_then(|addrs| addrs.into_iter().next())
+            .map(|addr| {
+                addr.address()
+                    .expect("get_address returned a non-address object")
+            }),
+    }
+}
+
+pub fn iter_admins(admins: &[Arc<mimir::Admin>]) -> impl Iterator<Item = &mimir::Admin> + Clone {
+    admins.iter().map(|a| a.deref())
+}

--- a/src/bin/fafnir.rs
+++ b/src/bin/fafnir.rs
@@ -1,57 +1,16 @@
 extern crate fafnir;
 extern crate mimirsbrunn;
-extern crate postgres;
-#[macro_use]
-extern crate structopt;
 extern crate num_cpus;
+extern crate postgres;
 
-#[derive(StructOpt, Debug)]
-#[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
-struct Args {
-    /// Postgresql parameters
-    #[structopt(long = "pg")]
-    pg: String,
-    /// Elasticsearch parameters.
-    #[structopt(long = "es", default_value = "http://localhost:9200/")]
-    es: String,
-    /// Name of the dataset.
-    #[structopt(short = "d", long = "dataset")]
-    dataset: String,
-    /// Number of threads used. The default is to use the number of cpus
-    #[structopt(short = "n", long = "nb-threads")]
-    nb_threads: Option<usize>,
-    /// Bounding box to filter the imported pois
-    /// The format is "lat1, lon1, lat2, lon2"
-    #[structopt(short = "b", long = "bounding-box")]
-    bounding_box: Option<String>,
-    /// Number of shards for the es index
-    #[structopt(short = "s", long = "nb-shards", default_value = "1")]
-    nb_shards: usize,
-    /// Number of replicas for the es index
-    #[structopt(short = "r", long = "nb-replicas", default_value = "1")]
-    nb_replicas: usize,
-    /// Languages codes, used to build i18n names and labels
-    #[structopt(name = "lang", short, long)]
-    langs: Vec<String>,
-}
+use fafnir::Args;
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
     let client = postgres::Client::connect(&args.pg, postgres::tls::NoTls).unwrap_or_else(|err| {
         panic!("Unable to connect to postgres: {}", err);
     });
-
-    let dataset = args.dataset;
     let nb_threads = args.nb_threads.unwrap_or_else(num_cpus::get);
-    fafnir::load_and_index_pois(
-        args.es,
-        client,
-        dataset,
-        nb_threads,
-        args.bounding_box,
-        args.nb_shards,
-        args.nb_replicas,
-        args.langs,
-    )
+    fafnir::load_and_index_pois(client, nb_threads, args)
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,6 @@ pub fn load_and_index_pois(
                 'airport' AS subclass,
                 tags
             FROM osm_aerodrome_label_point
-                WHERE name <> ''
             UNION ALL
             SELECT
                 geometry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,14 +143,15 @@ pub fn load_and_index_pois(
     };
 
     rubber.initialize_templates()?;
-    let poi_index: mimir::rubber::TypedIndex<Poi> =
-        rubber.make_index(&args.dataset, &index_settings).unwrap();
+    let poi_index: mimir::rubber::TypedIndex<Poi> = rubber
+        .make_index(&args.dataset, &index_settings)
+        .expect("failed to make index");
     let poi_index_nosearch: mimir::rubber::TypedIndex<Poi> = rubber
         .make_index(&args.dataset_nosearch, &index_settings)
-        .unwrap();
+        .expect("failed to make index");
 
     let mut total_nb_pois = 0;
-    let stmt = client.prepare(&query).unwrap();
+    let stmt = client.prepare(&query).expect("failed to prepare query");
     let rows_iterator = client
         .query_raw(&stmt, vec![])?
         .fuse() // Avoids consuming exhausted stream when using par_map
@@ -209,13 +210,13 @@ pub fn load_and_index_pois(
     info!("Total number of indexed pois: {}", total_nb_pois);
     rubber
         .publish_index(&args.dataset, poi_index, IndexVisibility::Public)
-        .unwrap();
+        .expect("failed to publish public index");
     rubber
         .publish_index(
             &args.dataset_nosearch,
             poi_index_nosearch,
             IndexVisibility::Private,
         )
-        .unwrap();
+        .expect("failed to publish private index");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub fn load_and_index_pois(
                 mapping_key,
                 subclass,
                 tags
-            FROM layer_poi(NULL, 14, 1)
+            FROM all_pois(14)
             UNION ALL
             SELECT
                 geometry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,338 +8,63 @@ extern crate itertools;
 extern crate num_cpus;
 extern crate par_map;
 
+mod addresses;
 mod pois;
+use crate::par_map::ParMap;
 use pois::IndexedPoi;
 
 use itertools::process_results;
 use mimir::rubber::{IndexSettings, IndexVisibility, Rubber};
-use mimir::{Coord, Poi, PoiType, Property};
-use mimirsbrunn::admin_geofinder::AdminGeoFinder;
-use mimirsbrunn::labels::format_international_poi_label;
-use mimirsbrunn::labels::{format_addr_name_and_label, format_poi_label, format_street_label};
-use mimirsbrunn::utils::find_country_codes;
-use std::ops::Deref;
+use mimir::Poi;
+use postgres::fallible_iterator::FallibleIterator;
+use postgres::Client;
 use std::time::Duration;
 
-use par_map::ParMap;
-use postgres::fallible_iterator::FallibleIterator;
-use postgres::row::Row;
-use postgres::Client;
-use std::collections::HashMap;
-use std::sync::Arc;
+#[macro_use]
+extern crate structopt;
 
 const ES_TIMEOUT: std::time::Duration = Duration::from_secs(30);
 
-fn properties_from_row(row: &Row) -> Result<Vec<Property>, String> {
-    let properties = row
-        .try_get::<_, Option<HashMap<_, _>>>("tags")
-        .map_err(|err| {
-            let id: String = row.get("id");
-            warn!("Unable to get tags from row '{}': {:?}", id, err);
-            err.to_string()
-        })?
-        .unwrap_or_else(HashMap::new)
-        .into_iter()
-        .map(|(k, v)| Property {
-            key: k,
-            value: v.unwrap_or_else(|| "".to_string()),
-        })
-        .collect::<Vec<Property>>();
-
-    Ok(properties)
-}
-
-fn build_names(langs: &[String], properties: &[Property]) -> Result<mimir::I18nProperties, String> {
-    const NAME_TAG_PREFIX: &str = "name:";
-
-    let properties = properties
-        .iter()
-        .filter_map(|property| {
-            if property.key.starts_with(&NAME_TAG_PREFIX) {
-                let lang = property.key[NAME_TAG_PREFIX.len()..].to_string();
-                if langs.contains(&lang) {
-                    Some(mimir::Property {
-                        key: lang,
-                        value: property.value.to_string(),
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    Ok(mimir::I18nProperties(properties))
-}
-
-fn build_poi_properties(
-    row: &Row,
-    id: &str,
-    mut properties: Vec<Property>,
-) -> Result<Vec<Property>, String> {
-    let poi_subclass = row.try_get("subclass").map_err(|e| {
-        warn!("impossible to get poi_subclass for {} because {}", id, e);
-        e.to_string()
-    })?;
-
-    let poi_class = row.try_get("class").map_err(|e| {
-        warn!("impossible to get poi_class for {} because {}", id, e);
-        e.to_string()
-    })?;
-
-    properties.push(Property {
-        key: "poi_subclass".to_string(),
-        value: poi_subclass,
-    });
-
-    properties.push(Property {
-        key: "poi_class".to_string(),
-        value: poi_class,
-    });
-
-    Ok(properties)
-}
-
-fn iter_admins(admins: &[Arc<mimir::Admin>]) -> impl Iterator<Item = &mimir::Admin> + Clone {
-    admins.iter().map(|a| a.deref())
-}
-
-/// Read the osm address tags and build a mimir address from them
-///
-/// For the moment we read mostly `addr:city` or `addr:country`
-/// if available we also read `addr:postcode`
-///
-/// We also search for the admins that contains the coordinates of the poi
-/// and add them as the address's admins.
-///
-/// For the moment we do not read `addr:city` or `addr:country` as it could
-/// lead to inconsistency with the admins hierarchy
-fn build_new_addr(
-    addr_tag: &str,
-    street_tag: &str,
-    poi: &Poi,
-    admins: Vec<Arc<mimir::Admin>>,
-) -> mimir::Address {
-    let postcode = poi
-        .properties
-        .iter()
-        .find(|p| &p.key == "addr:postcode")
-        .map(|p| p.value.clone());
-    let postcodes = postcode.map_or(vec![], |p| vec![p]);
-    let country_codes = find_country_codes(iter_admins(&admins));
-    let street_label = format_street_label(street_tag, iter_admins(&admins), &country_codes);
-    let (addr_name, addr_label) =
-        format_addr_name_and_label(addr_tag, street_tag, iter_admins(&admins), &country_codes);
-    let weight = admins.iter().find(|a| a.is_city()).map_or(0., |a| a.weight);
-    mimir::Address::Addr(mimir::Addr {
-        id: format!("addr_poi:{}", &poi.id),
-        house_number: addr_tag.into(),
-        name: addr_name,
-        street: mimir::Street {
-            id: format!("street_poi:{}", &poi.id),
-            name: street_tag.to_string(),
-            label: street_label,
-            administrative_regions: admins,
-            weight,
-            zip_codes: postcodes.clone(),
-            coord: poi.coord,
-            country_codes: country_codes.clone(),
-            ..Default::default()
-        },
-        label: addr_label,
-        coord: poi.coord,
-        approx_coord: None,
-        weight,
-        zip_codes: postcodes,
-        distance: None,
-        country_codes,
-        context: None,
-    })
-}
-
-fn find_address(
-    poi: &Poi,
-    geofinder: &AdminGeoFinder,
-    rubber: &mut Rubber,
-) -> Option<mimir::Address> {
-    if poi
-        .properties
-        .iter()
-        .any(|p| p.key == "poi_class" && p.value == "locality")
-    {
-        // We don't want to add address on hamlets.
-        return None;
-    }
-    let osm_addr_tag = ["addr:housenumber", "contact:housenumber"]
-        .iter()
-        .filter_map(|k| {
-            poi.properties
-                .iter()
-                .find(|p| &p.key == k)
-                .map(|p| &p.value)
-        })
-        .next();
-
-    let osm_street_tag = ["addr:street", "contact:street"]
-        .iter()
-        .filter_map(|k| {
-            poi.properties
-                .iter()
-                .find(|p| &p.key == k)
-                .map(|p| &p.value)
-        })
-        .next();
-
-    match (osm_addr_tag, osm_street_tag) {
-        (Some(addr_tag), Some(street_tag)) => Some(build_new_addr(
-            addr_tag,
-            street_tag,
-            poi,
-            geofinder.get(&poi.coord),
-        )),
-        _ => rubber
-            .get_address(&poi.coord)
-            .map_err(|e| {
-                warn!("get_address returned ES error for {}: {}", poi.id, e);
-                e
-            })
-            .ok()
-            .and_then(|addrs| addrs.into_iter().next())
-            .map(|addr| {
-                addr.address()
-                    .expect("get_address returned a non-address object")
-            }),
-    }
-}
-
-fn locate_poi(
-    mut poi: Poi,
-    geofinder: &AdminGeoFinder,
-    rubber: &mut Rubber,
-    langs: &[String],
-) -> Option<Poi> {
-    let poi_address = find_address(&poi, geofinder, rubber);
-
-    // if we have an address, we take the address's admin as the poi's admin
-    // else we lookup the admin by the poi's coordinates
-    let (admins, country_codes) = poi_address
-        .as_ref()
-        .map(|a| match a {
-            mimir::Address::Street(ref s) => {
-                (s.administrative_regions.clone(), s.country_codes.clone())
-            }
-            mimir::Address::Addr(ref s) => (
-                s.street.administrative_regions.clone(),
-                s.country_codes.clone(),
-            ),
-        })
-        .unwrap_or_else(|| {
-            let admins = geofinder.get(&poi.coord);
-            let country_codes = find_country_codes(iter_admins(&admins));
-            (admins, country_codes)
-        });
-
-    if admins.is_empty() {
-        debug!("The poi {} is not on any admins", &poi.id);
-        return None;
-    }
-
-    let zip_codes = match poi_address {
-        Some(mimir::Address::Street(ref s)) => s.zip_codes.clone(),
-        Some(mimir::Address::Addr(ref a)) => a.zip_codes.clone(),
-        _ => vec![],
-    };
-
-    poi.administrative_regions = admins;
-    poi.address = poi_address;
-    poi.label = format_poi_label(
-        &poi.name,
-        iter_admins(&poi.administrative_regions),
-        &country_codes,
-    );
-    poi.labels = format_international_poi_label(
-        &poi.names,
-        &poi.name,
-        &poi.label,
-        iter_admins(&poi.administrative_regions),
-        &country_codes,
-        langs,
-    );
-    poi.zip_codes = zip_codes;
-    Some(poi)
-}
-
-fn build_poi(row: Row, langs: &[String]) -> Option<pois::IndexedPoi> {
-    let id: String = row.get("id");
-    let name: String = row.get("name");
-
-    let mapping_key: String = row.get("mapping_key");
-    let class: String = row.get("class");
-    let subclass: String = row.get("subclass");
-
-    let poi_type_id: String = format!("class_{}:subclass_{}", class, subclass);
-    let poi_type_name: String = format!("class_{} subclass_{}", class, subclass);
-
-    let weight = row.get("weight");
-
-    let lat = row
-        .try_get("lat")
-        .map_err(|e| warn!("impossible to get lat for {} because {}", id, e))
-        .ok()?;
-    let lon = row
-        .try_get("lon")
-        .map_err(|e| warn!("impossible to get lon for {} because {}", id, e))
-        .ok()?;
-
-    let poi_coord = Coord::new(lon, lat);
-
-    if !poi_coord.is_valid() {
-        // Ignore PoI if its coords from db are invalid.
-        // Especially, NaN values may exist because of projection
-        // transformations around poles.
-        warn!("Got invalid coord for {} lon={},lat={}", id, lon, lat);
-        return None;
-    }
-
-    let row_properties = properties_from_row(&row).unwrap_or_else(|_| vec![]);
-
-    let names =
-        build_names(langs, &row_properties).unwrap_or_else(|_| mimir::I18nProperties::default());
-
-    let properties = build_poi_properties(&row, &id, row_properties).unwrap_or_else(|_| vec![]);
-
-    let poi = Poi {
-        id,
-        coord: poi_coord,
-        poi_type: PoiType {
-            id: poi_type_id,
-            name: poi_type_name,
-        },
-        label: "".into(),
-        properties,
-        name,
-        weight,
-        names,
-        labels: mimir::I18nProperties::default(),
-        ..Default::default()
-    };
-
-    let searchable = pois::is_searchable(&poi, &mapping_key, &subclass);
-    Some(pois::IndexedPoi { poi, searchable })
+#[derive(StructOpt, Debug)]
+#[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
+pub struct Args {
+    /// Postgresql parameters
+    #[structopt(long = "pg")]
+    pub pg: String,
+    /// Elasticsearch parameters.
+    #[structopt(long = "es", default_value = "http://localhost:9200/")]
+    es: String,
+    /// Dataset to store searchable POIs
+    #[structopt(short = "d", long = "dataset")]
+    dataset: String,
+    /// Dataset to store non-searchable POIs
+    #[structopt(long = "dataset-nosearch", default_value = "nosearch")]
+    dataset_nosearch: String,
+    /// Number of threads used. The default is to use the number of cpus
+    #[structopt(short = "n", long = "nb-threads")]
+    pub nb_threads: Option<usize>,
+    /// Bounding box to filter the imported pois
+    /// The format is "lat1, lon1, lat2, lon2"
+    #[structopt(short = "b", long = "bounding-box")]
+    bounding_box: Option<String>,
+    /// Number of shards for the es index
+    #[structopt(short = "s", long = "nb-shards", default_value = "1")]
+    nb_shards: usize,
+    /// Number of replicas for the es index
+    #[structopt(short = "r", long = "nb-replicas", default_value = "1")]
+    nb_replicas: usize,
+    /// Languages codes, used to build i18n names and labels
+    #[structopt(name = "lang", short, long)]
+    langs: Vec<String>,
 }
 
 pub fn load_and_index_pois(
-    es: String,
     mut client: Client,
-    dataset: String,
     nb_threads: usize,
-    bounding_box: Option<String>,
-    nb_shards: usize,
-    nb_replicas: usize,
-    langs: Vec<String>,
+    args: Args,
 ) -> Result<(), mimirsbrunn::Error> {
+    let es = args.es.clone();
+    let langs = &args.langs;
     let rubber = &mut mimir::rubber::Rubber::new(&es);
     let admins = rubber.get_all_admins().map_err(|err| {
         error!("Administratives regions not found in es db");
@@ -347,7 +72,9 @@ pub fn load_and_index_pois(
     })?;
     let admins_geofinder = admins.into_iter().collect();
 
-    let bbox_filter = bounding_box
+    let bbox_filter = args
+        .bounding_box
+        .as_ref()
         .map(|b| {
             format!(
                 "WHERE ST_MakeEnvelope({}, 4326) && st_transform(geometry, 4326)",
@@ -412,15 +139,16 @@ pub fn load_and_index_pois(
     );
 
     let index_settings = IndexSettings {
-        nb_shards,
-        nb_replicas,
+        nb_shards: args.nb_shards,
+        nb_replicas: args.nb_replicas,
     };
 
     rubber.initialize_templates()?;
     let poi_index: mimir::rubber::TypedIndex<Poi> =
-        rubber.make_index(&dataset, &index_settings).unwrap();
-    let poi_index_nosearch: mimir::rubber::TypedIndex<Poi> =
-        rubber.make_index("nosearch", &index_settings).unwrap();
+        rubber.make_index(&args.dataset, &index_settings).unwrap();
+    let poi_index_nosearch: mimir::rubber::TypedIndex<Poi> = rubber
+        .make_index(&args.dataset_nosearch, &index_settings)
+        .unwrap();
 
     let mut total_nb_pois = 0;
     let stmt = client.prepare(&query).unwrap();
@@ -434,33 +162,30 @@ pub fn load_and_index_pois(
     // "process_results" will early return on first error
     // from the postgres iterator
     process_results(rows_iterator, |rows| {
-        rows.filter_map(|row| build_poi(row, &langs))
-            .pack(2000)
+        rows.filter_map(|row| IndexedPoi::from_row(row, &langs))
+            .pack(1500)
             .with_nb_threads(nb_threads)
             .par_map({
-                let i = poi_index.clone();
-                let i_nosearch = poi_index_nosearch.clone();
+                let index = poi_index.clone();
+                let index_nosearch = poi_index_nosearch.clone();
                 let langs = langs.clone();
                 move |p| {
                     let mut rub = Rubber::new_with_timeout(&es, ES_TIMEOUT);
                     let pois = p.into_iter().filter_map(|indexed_poi| {
-                        let searchable = indexed_poi.searchable;
-                        let poi = indexed_poi.poi;
-                        locate_poi(poi, &admins_geofinder, &mut rub, &langs)
-                            .map(|poi| pois::IndexedPoi { poi, searchable })
+                        indexed_poi.locate_poi(&admins_geofinder, &mut rub, &langs)
                     });
-                    let mut rub2 = Rubber::new_with_timeout(&es, ES_TIMEOUT);
-
                     let (search, no_search): (Vec<IndexedPoi>, Vec<IndexedPoi>) =
-                        pois.partition(|p| p.searchable);
+                        pois.partition(|p| p.is_searchable);
                     let mut nb_indexed_pois = 0;
-                    match rub2.bulk_index(&i, search.into_iter().map(|indexed_poi| indexed_poi.poi))
-                    {
+                    match rub.bulk_index(
+                        &index,
+                        search.into_iter().map(|indexed_poi| indexed_poi.poi),
+                    ) {
                         Err(e) => panic!("Failed to bulk insert pois because: {}", e),
                         Ok(nb) => nb_indexed_pois += nb,
                     };
-                    match rub2.bulk_index(
-                        &i_nosearch,
+                    match rub.bulk_index(
+                        &index_nosearch,
                         no_search.into_iter().map(|indexed_poi| indexed_poi.poi),
                     ) {
                         Err(e) => panic!("Failed to bulk insert pois because: {}", e),
@@ -484,10 +209,14 @@ pub fn load_and_index_pois(
 
     info!("Total number of indexed pois: {}", total_nb_pois);
     rubber
-        .publish_index(&dataset, poi_index, IndexVisibility::Public)
+        .publish_index(&args.dataset, poi_index, IndexVisibility::Public)
         .unwrap();
     rubber
-        .publish_index("nosearch", poi_index_nosearch, IndexVisibility::Private)
+        .publish_index(
+            &args.dataset_nosearch,
+            poi_index_nosearch,
+            IndexVisibility::Private,
+        )
         .unwrap();
     Ok(())
 }

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -1,6 +1,5 @@
 use crate::addresses::find_address;
 use crate::addresses::iter_admins;
-use lazy_static::lazy_static;
 use mimir::rubber::Rubber;
 use mimir::Poi;
 use mimir::Property;
@@ -13,8 +12,10 @@ use postgres::Row;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 
-lazy_static! {
-    static ref NON_SEARCHABLE_ITEMS: BTreeSet<(String, String)> = [
+use once_cell::sync::Lazy;
+
+static NON_SEARCHABLE_ITEMS: Lazy<BTreeSet<(String, String)>> = Lazy::new(|| {
+    [
         /* List of (mapping_key, subclass) */
         ("highway", "bus_stop"),
         ("barrier", "gate"),
@@ -42,8 +43,8 @@ lazy_static! {
     ]
     .iter()
     .map(|(a, b)| ((*a).to_string(), (*b).to_string()))
-    .collect();
-}
+    .collect()
+});
 
 pub struct IndexedPoi {
     pub poi: Poi,

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -1,0 +1,45 @@
+use lazy_static::lazy_static;
+use mimir::Poi;
+use std::collections::BTreeSet;
+
+lazy_static! {
+    static ref NOT_SEARCHABLE_ITEMS: BTreeSet<(String, String)> = [
+        /* List of (mapping_key, subclass) */
+        ("highway", "bus_stop"),
+        ("barrier", "gate"),
+        ("amenity", "waste_basket"),
+        ("amenity", "post_box"),
+        ("tourism", "information"),
+        ("amenity", "recycling"),
+        ("barrier", "lift_gate"),
+        ("barrier", "bollard"),
+        ("barrier", "cycle_barrier"),
+        ("amenity", "bicycle_rental"),
+        ("tourism", "artwork"),
+        ("amenity", "toilets"),
+        ("leisure", "playground"),
+        ("amenity", "telephone"),
+        ("amenity", "taxi"),
+        ("leisure", "pitch"),
+        ("amenity", "shelter"),
+        ("barrier", "sally_port"),
+        ("barrier", "stile"),
+        ("amenity", "ferry_terminal"),
+        ("amenity", "post_office"),
+        ("railway", "subway_entrance"),
+        ("railway", "train_station_entrance"),
+    ]
+    .into_iter()
+    .map(|(a, b)| (a.to_string(), b.to_string()))
+    .collect();
+}
+
+pub struct IndexedPoi {
+    pub poi: Poi,
+    pub searchable: bool,
+}
+
+pub fn is_searchable(poi: &Poi, mapping_key: &str, subclass: &str) -> bool {
+    return !poi.name.is_empty()
+        && !NOT_SEARCHABLE_ITEMS.contains(&(mapping_key.into(), subclass.into()));
+}

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -1,9 +1,20 @@
+use crate::addresses::find_address;
+use crate::addresses::iter_admins;
 use lazy_static::lazy_static;
+use mimir::rubber::Rubber;
 use mimir::Poi;
+use mimir::Property;
+use mimir::{Coord, PoiType};
+use mimirsbrunn::admin_geofinder::AdminGeoFinder;
+use mimirsbrunn::labels::format_international_poi_label;
+use mimirsbrunn::labels::format_poi_label;
+use mimirsbrunn::utils::find_country_codes;
+use postgres::Row;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 
 lazy_static! {
-    static ref NOT_SEARCHABLE_ITEMS: BTreeSet<(String, String)> = [
+    static ref NON_SEARCHABLE_ITEMS: BTreeSet<(String, String)> = [
         /* List of (mapping_key, subclass) */
         ("highway", "bus_stop"),
         ("barrier", "gate"),
@@ -29,17 +40,204 @@ lazy_static! {
         ("railway", "subway_entrance"),
         ("railway", "train_station_entrance"),
     ]
-    .into_iter()
-    .map(|(a, b)| (a.to_string(), b.to_string()))
+    .iter()
+    .map(|(a, b)| ((*a).to_string(), (*b).to_string()))
     .collect();
 }
 
 pub struct IndexedPoi {
     pub poi: Poi,
-    pub searchable: bool,
+    pub is_searchable: bool,
 }
 
-pub fn is_searchable(poi: &Poi, mapping_key: &str, subclass: &str) -> bool {
-    return !poi.name.is_empty()
-        && !NOT_SEARCHABLE_ITEMS.contains(&(mapping_key.into(), subclass.into()));
+impl IndexedPoi {
+    pub fn from_row(row: Row, langs: &[String]) -> Option<IndexedPoi> {
+        let id: String = row.get("id");
+        let name: String = row.get("name");
+
+        let mapping_key: String = row.get("mapping_key");
+        let class: String = row.get("class");
+        let subclass: String = row.get("subclass");
+
+        let poi_type_id: String = format!("class_{}:subclass_{}", class, subclass);
+        let poi_type_name: String = format!("class_{} subclass_{}", class, subclass);
+
+        let weight = row.get("weight");
+
+        let lat = row
+            .try_get("lat")
+            .map_err(|e| warn!("impossible to get lat for {} because {}", id, e))
+            .ok()?;
+        let lon = row
+            .try_get("lon")
+            .map_err(|e| warn!("impossible to get lon for {} because {}", id, e))
+            .ok()?;
+
+        let poi_coord = Coord::new(lon, lat);
+
+        if !poi_coord.is_valid() {
+            // Ignore PoI if its coords from db are invalid.
+            // Especially, NaN values may exist because of projection
+            // transformations around poles.
+            warn!("Got invalid coord for {} lon={},lat={}", id, lon, lat);
+            return None;
+        }
+
+        let row_properties = properties_from_row(&row).unwrap_or_else(|_| vec![]);
+
+        let names = build_names(langs, &row_properties)
+            .unwrap_or_else(|_| mimir::I18nProperties::default());
+
+        let properties = build_poi_properties(&row, &id, row_properties).unwrap_or_else(|_| vec![]);
+
+        let is_searchable =
+            !name.is_empty() && !NON_SEARCHABLE_ITEMS.contains(&(mapping_key, subclass));
+
+        let poi = Poi {
+            id,
+            coord: poi_coord,
+            poi_type: PoiType {
+                id: poi_type_id,
+                name: poi_type_name,
+            },
+            label: "".into(),
+            properties,
+            name,
+            weight,
+            names,
+            labels: mimir::I18nProperties::default(),
+            ..Default::default()
+        };
+
+        Some(IndexedPoi { poi, is_searchable })
+    }
+
+    pub fn locate_poi(
+        mut self,
+        geofinder: &AdminGeoFinder,
+        rubber: &mut Rubber,
+        langs: &[String],
+    ) -> Option<IndexedPoi> {
+        let poi_address = find_address(&self.poi, geofinder, rubber);
+
+        // if we have an address, we take the address's admin as the poi's admin
+        // else we lookup the admin by the poi's coordinates
+        let (admins, country_codes) = poi_address
+            .as_ref()
+            .map(|a| match a {
+                mimir::Address::Street(ref s) => {
+                    (s.administrative_regions.clone(), s.country_codes.clone())
+                }
+                mimir::Address::Addr(ref s) => (
+                    s.street.administrative_regions.clone(),
+                    s.country_codes.clone(),
+                ),
+            })
+            .unwrap_or_else(|| {
+                let admins = geofinder.get(&self.poi.coord);
+                let country_codes = find_country_codes(iter_admins(&admins));
+                (admins, country_codes)
+            });
+
+        if admins.is_empty() {
+            debug!("The poi {} is not on any admins", &self.poi.id);
+            return None;
+        }
+
+        let zip_codes = match poi_address {
+            Some(mimir::Address::Street(ref s)) => s.zip_codes.clone(),
+            Some(mimir::Address::Addr(ref a)) => a.zip_codes.clone(),
+            _ => vec![],
+        };
+
+        self.poi.administrative_regions = admins;
+        self.poi.address = poi_address;
+        self.poi.label = format_poi_label(
+            &self.poi.name,
+            iter_admins(&self.poi.administrative_regions),
+            &country_codes,
+        );
+        self.poi.labels = format_international_poi_label(
+            &self.poi.names,
+            &self.poi.name,
+            &self.poi.label,
+            iter_admins(&self.poi.administrative_regions),
+            &country_codes,
+            langs,
+        );
+        self.poi.zip_codes = zip_codes;
+        Some(self)
+    }
+}
+
+fn properties_from_row(row: &Row) -> Result<Vec<Property>, String> {
+    let properties = row
+        .try_get::<_, Option<HashMap<_, _>>>("tags")
+        .map_err(|err| {
+            let id: String = row.get("id");
+            warn!("Unable to get tags from row '{}': {:?}", id, err);
+            err.to_string()
+        })?
+        .unwrap_or_else(HashMap::new)
+        .into_iter()
+        .map(|(k, v)| Property {
+            key: k,
+            value: v.unwrap_or_else(|| "".to_string()),
+        })
+        .collect::<Vec<Property>>();
+
+    Ok(properties)
+}
+
+fn build_poi_properties(
+    row: &Row,
+    id: &str,
+    mut properties: Vec<Property>,
+) -> Result<Vec<Property>, String> {
+    let poi_subclass = row.try_get("subclass").map_err(|e| {
+        warn!("impossible to get poi_subclass for {} because {}", id, e);
+        e.to_string()
+    })?;
+
+    let poi_class = row.try_get("class").map_err(|e| {
+        warn!("impossible to get poi_class for {} because {}", id, e);
+        e.to_string()
+    })?;
+
+    properties.push(Property {
+        key: "poi_subclass".to_string(),
+        value: poi_subclass,
+    });
+
+    properties.push(Property {
+        key: "poi_class".to_string(),
+        value: poi_class,
+    });
+
+    Ok(properties)
+}
+
+fn build_names(langs: &[String], properties: &[Property]) -> Result<mimir::I18nProperties, String> {
+    const NAME_TAG_PREFIX: &str = "name:";
+
+    let properties = properties
+        .iter()
+        .filter_map(|property| {
+            if property.key.starts_with(&NAME_TAG_PREFIX) {
+                let lang = property.key[NAME_TAG_PREFIX.len()..].to_string();
+                if langs.contains(&lang) {
+                    Some(mimir::Property {
+                        key: lang,
+                        value: property.value.to_string(),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(mimir::I18nProperties(properties))
 }

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -226,16 +226,13 @@ fn build_names(langs: &[String], properties: &[Property]) -> Result<mimir::I18nP
             if property.key.starts_with(&NAME_TAG_PREFIX) {
                 let lang = property.key[NAME_TAG_PREFIX.len()..].to_string();
                 if langs.contains(&lang) {
-                    Some(mimir::Property {
+                    return Some(mimir::Property {
                         key: lang,
                         value: property.value.to_string(),
-                    })
-                } else {
-                    None
+                    });
                 }
-            } else {
-                None
             }
+            None
         })
         .collect();
 

--- a/tests/docker_wrapper/mod.rs
+++ b/tests/docker_wrapper/mod.rs
@@ -80,7 +80,9 @@ impl ElasticsearchDocker {
         let mut el_docker = ElasticsearchDocker { ip: "".to_string() };
         el_docker.setup()?;
         let rubber = Rubber::new(&el_docker.host());
-        &rubber.initialize_templates().unwrap();
+        &rubber
+            .initialize_templates()
+            .expect("failed to initialize ES templates");
         Ok(el_docker)
     }
 

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -735,7 +735,7 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
     let nosearch_pois: Vec<mimir::Poi> = es_wrapper
         .rubber
         .get_all_objects_from_index("munin_poi_nosearch")
-        .unwrap();
+        .expect("failed to fetch poi_nosearch documents");
     assert_eq!(nosearch_pois.len(), 1);
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -138,7 +138,7 @@ impl<'a> ElasticSearchWrapper<'a> {
     pub fn search(&self, word: &str) -> serde_json::Value {
         let mut res = self
             .rubber
-            .get(&format!("munin/_search?q={}", word))
+            .get(&format!("munin/_search?q={}&size=100", word))
             .unwrap();
         assert!(res.status().is_success());
         res.json().expect("failed to parse json")


### PR DESCRIPTION
Non searchable POIs, that were ignored, are now imported in a new dataset (called "nosearch" by default).
It is published with `IndexVisibility::Private` to NOT be included into geocoder results.


This PR comes with a bit of refactoring. Most of these changes are just functions that have been moved from `lib.rs`