### PR TITLE
Skip reverse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,8 +1037,9 @@ dependencies = [
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.12.2 (git+https://github.com/canaltp/rs-es)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2911,17 +2912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rs-es"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rstar"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,7 +4416,6 @@ dependencies = [
 "checksum retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rs-es 0.12.2 (git+https://github.com/canaltp/rs-es)" = "<none>"
-"checksum rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4518f08ae3b50d9fdf37b5ba607c49f6573050fe212b7e8b27083e52bf20c9"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
 "checksum rust-argon2 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81ed8d04228b44a740c8d46ff872a28e50fff3d659f307ab4da2cc502e019ff3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.8"
 par-map = "0.1.4"
 num_cpus = "1.12"
 once_cell = "1.3"
+reqwest = "0.9"
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 
@@ -25,7 +26,7 @@ retry = "*"
 hyper = "0.10"
 bragi = { git = "https://github.com/canalTP/mimirsbrunn", rev = "456e0be" }
 cosmogony = "0.7"
-rs-es = {version = "0.12", default-features = false}
+rs-es = {git = "https://github.com/canaltp/rs-es", default-features = false}
 serde_derive = "1"
 failure = "0.1"
 approx = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ itertools = "0.8"
 par-map = "0.1.4"
 num_cpus = "1.12"
 once_cell = "1.3"
+serde = {version = "1", features = ["rc"]}
+serde_json = "1"
 
 [dev-dependencies]
 retry = "*"
@@ -24,8 +26,6 @@ hyper = "0.10"
 bragi = { git = "https://github.com/canalTP/mimirsbrunn", rev = "456e0be" }
 cosmogony = "0.7"
 rs-es = {version = "0.12", default-features = false}
-serde = {version = "1", features = ["rc"]}
 serde_derive = "1"
-serde_json = "1"
 failure = "0.1"
 approx = "0.2.0"

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -219,7 +219,9 @@ pub fn find_address(
 
                 match get_current_addr(rubber, poi_index, &poi.id) {
                     CurPoiAddress::None { coord } if !changed_coords(coord) => return None,
-                    CurPoiAddress::Some { coord, address } if !changed_coords(coord) => {
+                    CurPoiAddress::Some { coord, address }
+                        if !is_osm_addr(&address) && !changed_coords(coord) =>
+                    {
                         return Some(address);
                     }
                     _ => {}

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -141,14 +141,14 @@ fn build_new_addr(
 /// We also search for the admins that contains the coordinates of the poi
 /// and add them as the address's admins.
 ///
-/// If addr_updated is set to false, we will reuse the address already
+/// If try_skip_reverse is set to try, it will reuse the address already
 /// attached to a POI in the ES database.
 pub fn find_address(
     poi: &Poi,
     geofinder: &AdminGeoFinder,
     rubber: &mut Rubber,
     poi_index: &str,
-    addr_updated: bool,
+    try_skip_reverse: bool,
 ) -> Option<mimir::Address> {
     if poi
         .properties
@@ -209,7 +209,7 @@ pub fn find_address(
             ))
         }
         _ => {
-            if !addr_updated {
+            if try_skip_reverse {
                 // Fetch the address already attached to the POI to avoid computing an unnecessary
                 // reverse.
                 let changed_coords = |old_coord: mimir::Coord| {

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -16,8 +16,9 @@ pub fn is_osm_addr(addr: &mimir::Address) -> bool {
     }
 }
 
-/// Get current value of address associated with a POI in the ES database if any together with
-/// current coordinates of the POI that have been used to perform a reverse.
+/// Get current value of address associated with a POI in the ES database if
+/// any, together with current coordinates of the POI that have been used to
+/// perform a reverse
 pub fn get_current_addr(
     rubber: &mut Rubber,
     poi_index: &str,
@@ -99,9 +100,9 @@ fn build_new_addr(
             label: street_label,
             administrative_regions: admins,
             weight,
-            zip_codes: postcodes.clone(),
+            zip_codes: postcodes,
             coord: poi.coord,
-            country_codes: country_codes.clone(),
+            country_codes,
             ..Default::default()
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@ pub struct Args {
     /// Languages codes, used to build i18n names and labels
     #[structopt(name = "lang", short, long)]
     langs: Vec<String>,
+    /// Do not skip reverse when address information can be retrieved from previous data
+    #[structopt(long)]
+    no_skip_reverse: bool,
 }
 
 pub fn load_and_index_pois(
@@ -81,7 +84,8 @@ pub fn load_and_index_pois(
         (Some(poi_ts), Some(addr_ts)) => addr_ts > poi_ts,
         _ => true,
     };
-    if !addr_updated {
+    let try_skip_reverse = !args.no_skip_reverse && !addr_updated;
+    if try_skip_reverse {
         info!("addresses have not been updated since last update, reverse on old POIs won't be performed");
     }
 
@@ -200,7 +204,7 @@ pub fn load_and_index_pois(
                             &langs,
                             &poi_index_name,
                             &poi_index_nosearch_name,
-                            addr_updated,
+                            try_skip_reverse,
                         )
                     });
                     let (search, no_search): (Vec<IndexedPoi>, Vec<IndexedPoi>) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ extern crate structopt;
 
 const ES_TIMEOUT: std::time::Duration = Duration::from_secs(30);
 
+// Prefix to ES index names for mimirsbrunn
+const MIMIR_PREFIX: &str = "munin";
+
 #[derive(StructOpt, Debug)]
 #[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Args {
@@ -71,8 +74,8 @@ pub fn load_and_index_pois(
     let langs = &args.langs;
     let rubber = &mut mimir::rubber::Rubber::new(&es);
 
-    let poi_creation_date = get_index_creation_date(rubber, &format!("{}_poi", &args.dataset));
-    let addr_creation_date = get_index_creation_date(rubber, &format!("{}_addr", &args.dataset));
+    let poi_creation_date = get_index_creation_date(rubber, &format!("{}_poi", MIMIR_PREFIX));
+    let addr_creation_date = get_index_creation_date(rubber, &format!("{}_addr", MIMIR_PREFIX));
 
     let addr_updated = match (poi_creation_date, addr_creation_date) {
         (Some(poi_ts), Some(addr_ts)) => addr_ts > poi_ts,
@@ -175,8 +178,8 @@ pub fn load_and_index_pois(
 
     info!("Processing query results...");
 
-    let poi_index_name = format!("{}/poi", args.dataset);
-    let poi_index_nosearch_name = format!("{}/poi", args.dataset_nosearch);
+    let poi_index_name = format!("{}_poi_{}", MIMIR_PREFIX, args.dataset);
+    let poi_index_nosearch_name = format!("{}_poi_{}", MIMIR_PREFIX, args.dataset_nosearch);
 
     // "process_results" will early return on first error
     // from the postgres iterator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ mod pois;
 use crate::par_map::ParMap;
 use pois::IndexedPoi;
 
-use addresses::get_current_addr;
 use itertools::process_results;
 use mimir::rubber::{IndexSettings, IndexVisibility, Rubber};
 use mimir::Poi;
@@ -69,7 +68,7 @@ pub fn load_and_index_pois(
     let es = args.es.clone();
     let langs = &args.langs;
     let rubber = &mut mimir::rubber::Rubber::new(&es);
-    let poi_dataset = format!("{}_poi_default", &args.dataset); // TODO: is this right?
+    let poi_dataset = format!("{}_poi_default", &args.dataset); // TODO: is `{}_poi_default` right?
     let admins = rubber.get_all_admins().map_err(|err| {
         error!("Administratives regions not found in es db");
         err

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -119,9 +119,17 @@ impl IndexedPoi {
         geofinder: &AdminGeoFinder,
         rubber: &mut Rubber,
         langs: &[String],
-        poi_dataset: &str,
+        poi_index: &str,
+        poi_index_nosearch: &str,
+        addr_updated: bool,
     ) -> Option<IndexedPoi> {
-        let poi_address = find_address(&self.poi, geofinder, rubber, poi_dataset);
+        let index = if self.is_searchable {
+            poi_index
+        } else {
+            poi_index_nosearch
+        };
+
+        let poi_address = find_address(&self.poi, geofinder, rubber, index, addr_updated);
 
         // if we have an address, we take the address's admin as the poi's admin
         // else we lookup the admin by the poi's coordinates

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -119,8 +119,9 @@ impl IndexedPoi {
         geofinder: &AdminGeoFinder,
         rubber: &mut Rubber,
         langs: &[String],
+        poi_dataset: &str,
     ) -> Option<IndexedPoi> {
-        let poi_address = find_address(&self.poi, geofinder, rubber);
+        let poi_address = find_address(&self.poi, geofinder, rubber, poi_dataset);
 
         // if we have an address, we take the address's admin as the poi's admin
         // else we lookup the admin by the poi's coordinates

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -121,7 +121,7 @@ impl IndexedPoi {
         langs: &[String],
         poi_index: &str,
         poi_index_nosearch: &str,
-        addr_updated: bool,
+        try_skip_reverse: bool,
     ) -> Option<IndexedPoi> {
         let index = if self.is_searchable {
             poi_index
@@ -129,7 +129,7 @@ impl IndexedPoi {
             poi_index_nosearch
         };
 
-        let poi_address = find_address(&self.poi, geofinder, rubber, index, addr_updated);
+        let poi_address = find_address(&self.poi, geofinder, rubber, index, try_skip_reverse);
 
         // if we have an address, we take the address's admin as the poi's admin
         // else we lookup the admin by the poi's coordinates

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use mimir::rubber::Rubber;
 
 /// Get creation date of an index as a timestamp.
-pub fn get_index_creation_date(rubber: &mut Rubber, dataset: &str) -> Option<u64> {
-    let query = format!("/_cat/indices/{}?h=creation.date", dataset);
+pub fn get_index_creation_date(rubber: &mut Rubber, index: &str) -> Option<u64> {
+    let query = format!("/_cat/indices/{}?h=creation.date", index);
 
     rubber
         .get(&query)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,22 @@
+use mimir::rubber::Rubber;
+
+/// Get creation date of an index as a timestamp.
+pub fn get_index_creation_date(rubber: &mut Rubber, dataset: &str) -> Option<u64> {
+    let query = format!("/_cat/indices/{}?h=creation.date", dataset);
+
+    rubber
+        .get(&query)
+        .map_err(|err| warn!("could not query ES: {:?}", err))
+        .ok()
+        .and_then(|mut res| {
+            res.text()
+                .map_err(|err| warn!("could not load ES response: {:?}", err))
+                .ok()
+        })
+        .and_then(|text| {
+            text.trim()
+                .parse()
+                .map_err(|err| warn!("invalid index creation timestamp: {:?}", err))
+                .ok()
+        })
+}


### PR DESCRIPTION
Tries sparing part of the cost of reverse in fafnir by querying the ES for already existing address associated with a POI.