### PR TITLE
update mimirsbrunn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "bragi"
 version = "1.15.0"
-source = "git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c#478ff0c3202b8d5b07c98b62875e00699495be47"
+source = "git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db#e87d6db1d7aae6244e6e9ec7e56e417d331fc732"
 dependencies = [
  "actix-cors 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -464,10 +464,10 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
+ "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.12.2 (git+https://github.com/canaltp/rs-es)",
@@ -1024,15 +1024,15 @@ name = "fafnir"
 version = "0.3.8"
 dependencies = [
  "approx 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
+ "bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
  "cosmogony 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
- "mimirsbrunn 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
+ "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
+ "mimirsbrunn 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1306,8 +1306,23 @@ dependencies = [
 
 [[package]]
 name = "git-version"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "git-version-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "glob"
@@ -1775,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "1.15.0"
-source = "git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c#478ff0c3202b8d5b07c98b62875e00699495be47"
+source = "git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db#e87d6db1d7aae6244e6e9ec7e56e417d331fc732"
 dependencies = [
  "address-formatter 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1808,12 +1823,12 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "1.15.0"
-source = "git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c#478ff0c3202b8d5b07c98b62875e00699495be47"
+source = "git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db#e87d6db1d7aae6244e6e9ec7e56e417d331fc732"
 dependencies = [
  "address-formatter 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_float_eq 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
+ "bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmogony 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1821,13 +1836,12 @@ dependencies = [
  "flate2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "humanesort 0.1.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)",
+ "mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)",
  "navitia-poi-model 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4126,7 +4140,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "461f4b879a8eb70c1debf7d0788a9a5ff15f1ea9d25925fea264ef4258bed6b2"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)" = "<none>"
+"checksum bragi 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)" = "<none>"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum bstr 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94cdf78eb7e94c566c1f5dbe2abf8fc70a548fc902942a48c4b3a98b48ca9ade"
@@ -4219,7 +4233,8 @@ dependencies = [
 "checksum geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
 "checksum geojson 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ac03428b3276fc7f1756eba0c76c7c0c91ef77e1c43fbdd47a460238419cb9"
 "checksum getrandom 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2512b3191f22e2763a5db387f1c9409379772e2050841722eb4a8c4f497bf096"
-"checksum git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bc37021f50d852a4b134b05722b1c8e0ec7cd14262471e89a14a3df12c44a6"
+"checksum git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
+"checksum git-version-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
@@ -4273,8 +4288,8 @@ dependencies = [
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
-"checksum mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)" = "<none>"
-"checksum mimirsbrunn 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=478ff0c)" = "<none>"
+"checksum mimir 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)" = "<none>"
+"checksum mimirsbrunn 1.15.0 (git+https://github.com/canalTP/mimirsbrunn?rev=e87d6db)" = "<none>"
 "checksum minidom 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0a5296bf9d0ac9e4a6e4cb844e3ee84bf33f841c7b3ae2cc87f05ceb81b50ae"
 "checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 geo-types = "0.4"
 postgres = "0.17.4"
-mimirsbrunn = { git = "https://github.com/canalTP/mimirsbrunn", rev = "478ff0c" }
-mimir = { git = "https://github.com/canalTP/mimirsbrunn", rev = "478ff0c" }
+mimirsbrunn = { git = "https://github.com/canalTP/mimirsbrunn", rev = "e87d6db" }
+mimir = { git = "https://github.com/canalTP/mimirsbrunn", rev = "e87d6db" }
 structopt = "0.3"
 log = { version = "0.4", features = ["release_max_level_info"] }
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
@@ -24,7 +24,7 @@ serde_json = "1"
 [dev-dependencies]
 retry = "*"
 hyper = "0.10"
-bragi = { git = "https://github.com/canalTP/mimirsbrunn", rev = "478ff0c" }
+bragi = { git = "https://github.com/canalTP/mimirsbrunn", rev = "e87d6db" }
 cosmogony = "0.7"
 rs-es = {git = "https://github.com/canaltp/rs-es", default-features = false, rev = "ea4913e"}
 serde_derive = "1"


### PR DESCRIPTION
My main motivation is to fetch https://github.com/CanalTP/mimirsbrunn/pull/411 which prevent cargo to recompile mimir at each call.