### PR TITLE
pois: Include amenity=recycling in searchable items

### DIFF
--- a/src/pois.rs
+++ b/src/pois.rs
@@ -24,7 +24,6 @@ static NON_SEARCHABLE_ITEMS: Lazy<BTreeSet<(String, String)>> = Lazy::new(|| {
         ("amenity", "waste_basket"),
         ("amenity", "post_box"),
         ("tourism", "information"),
-        ("amenity", "recycling"),
         ("barrier", "lift_gate"),
         ("barrier", "bollard"),
         ("barrier", "cycle_barrier"),


### PR DESCRIPTION
Most of these items (with a name) are recycling centers, and are worth being searchable by their name.

```
# select tags->'recycling_type', count(*) from all_pois(14) where class = 'recycling' and name <> '' group by 1 order by 2 desc limit 10;

       ?column?       | count 
----------------------+-------
 centre               | 13296
 container            |  5530
                      |  5122
 container mobile     |    33
 center               |     7
 station              |     7
 underfloor-container |     6
 dump                 |     6
 green_waster_area    |     4
 building             |     4
(10 rows)
```