### PR TITLE
Force log max_level to "info"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "fafnir"
-version = "0.3.8"
+version = "0.3.12"
 dependencies = [
  "approx 0.2.1",
  "bragi",

--- a/src/bin/fafnir.rs
+++ b/src/bin/fafnir.rs
@@ -1,12 +1,8 @@
-extern crate fafnir;
-extern crate log;
-extern crate mimirsbrunn;
-extern crate num_cpus;
-extern crate postgres;
-
 use fafnir::Args;
+use log::LevelFilter;
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
+    log::set_max_level(LevelFilter::Info);
     let client = postgres::Client::connect(&args.pg, postgres::tls::NoTls).unwrap_or_else(|err| {
         panic!("Unable to connect to postgres: {}", err);
     });


### PR DESCRIPTION
I would have thought that enabling the feature `release_max_level_info` would be sufficient. But I can still observe this kind of messages with the current master:
```
Dec 04 17:00:23.064 ERRO slog-async: logger dropped messages due to channel overflow, count: 97
```

I must say that the interactions between `log`, `tracing`, `slog`, `slog_scope`, `slog_async`, etc. (used by mimirsbrunn and its dependencies) are deeply confusing :sob: 

So this PR seems to solve the issue for now, but we could need to dig into this at some point.